### PR TITLE
Fix base32 default encoding

### DIFF
--- a/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
+++ b/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
@@ -16,6 +16,7 @@
 package io.matthewnelson.encoding.base16
 
 import io.matthewnelson.encoding.builders.Base16
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.encoding.test.BaseNEncodingTest
@@ -176,5 +177,16 @@ class Base16UnitTest: BaseNEncodingTest() {
     fun givenBase16_whenLowercaseAndUppercaseChars_thenMatch() {
         assertEquals(Base16.CHARS_UPPER, Base16.CHARS_LOWER.uppercase())
         assertEquals(Base16.CHARS_LOWER, Base16.CHARS_UPPER.lowercase())
+    }
+
+    @Test
+    fun givenBase16_whenDecodeEncode_thenReturnsSameValue() {
+        val expected = "54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f672e"
+        val base16 = Base16(base16.config) {
+            encodeToLowercase = true
+        }
+        val decoded = expected.decodeToByteArray(base16)
+        val rencoded = decoded.encodeToString(base16)
+        assertEquals(expected, rencoded)
     }
 }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -20,6 +20,7 @@ package io.matthewnelson.encoding.base32
 import io.matthewnelson.encoding.base32.internal.decodeOutMaxSize
 import io.matthewnelson.encoding.base32.internal.encodeOutSize
 import io.matthewnelson.encoding.base32.internal.isCheckSymbol
+import io.matthewnelson.encoding.base32.internal.toBits
 import io.matthewnelson.encoding.builders.*
 import io.matthewnelson.encoding.core.*
 import io.matthewnelson.encoding.core.util.*
@@ -732,7 +733,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
 
             // Append each char's 8 bits to the bitBuffer
             for (bits in buffer) {
-                bitBuffer =  (bitBuffer shl  8) + bits
+                bitBuffer =  (bitBuffer shl  8) + bits.toByte().toBits()
             }
 
             // For every 5 chars of input, we accumulate
@@ -751,7 +752,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
 
             // Append each char remaining in the buffer to the bitBuffer
             for (i in 0 until modulus) {
-                bitBuffer =  (bitBuffer shl  8) + buffer[i]
+                bitBuffer =  (bitBuffer shl  8) + buffer[i].toByte().toBits()
             }
 
             val padCount: Int = when (modulus) {

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/internal/-Math.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/internal/-Math.kt
@@ -35,3 +35,6 @@ internal inline fun Long.encodeOutSize(willBePadded: Boolean): Long {
 
     return outSize
 }
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun Byte.toBits(): Long = if (this < 0) this + 256L else toLong()

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
@@ -47,6 +47,23 @@ class Base32CrockfordUnitTest: BaseNEncodingTest() {
 
     override val decodeSuccessDataSet: Set<Data<String, ByteArray>> = setOf(
         decodeSuccessHelloWorld,
+        Data(
+            raw = "ADGPRX35CHFNZY345TTVTGGJWD537QZAVVDSAXAVAZ0PSNPAZSMX30EVTF4R7X4HPD62E7QEEXB16Q9RC1S0E7J79W0FX7YDP6HN6S8",
+            expected = ("53 61 6c 74 65 64 5f 5f f8 64 2e b5 bd 42 12 e3 4a 33 df ea de db 95 75 5b 57 c1 " +
+                    "6c d6 ca fe 69 d1 81 db d3 c9 83 f4 91 b3 4c 27 1e ee 77 56 13 5d 38 60 72 07 1e 47 " +
+                    "4f 00 fe 9f cd b1 a3 53 65").decodeHexToByteArray()
+        ),
+        Data(
+            raw = "ADGPRX35CHFNZHQS2E9EKVGSVA5C2669DJFAAVEVNXV9FQ8NTBD5RNVXEME5WTDFMP76BG677TG8E",
+            expected = ("53 61 6c 74 65 64 5f 5f c6 f9 13 92 e9 ee 19 da 8a c1 18 c9 6c 9e a5 " +
+                    "6d db af 76 97 dd 15 d2 da 5c 57 7d 75 1c 5e 69 af a5 8e 65 c0 c7 3e a0 " +
+                    "87").decodeHexToByteArray()
+        ),
+        Data(
+            raw = "ADGPRX35CHFNZWWMJ1QFN78GY6RXZR0F80AG2EMQXGFMHEKPNPMG",
+            expected = ("53 61 6c 74 65 64 5f 5f f3 94 90 6e fa 9d 10 f1 b1 df e0 0f 40 15 01 " +
+                    "3a 97 ec 1f 48 ba 76 ad a9").decodeHexToByteArray()
+        ),
         Data(raw = " 91JP RV3F41B PYW KCC GGG  ", expected = "Hello World!".encodeToByteArray(), message = "Spaces ' ' should be ignored"),
         Data(raw = "-----", expected = ByteArray(0), message = "Decoding a String containing only hyphens '-' should return an empty ByteArray"),
 

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
@@ -18,6 +18,7 @@
 package io.matthewnelson.encoding.base32
 
 import io.matthewnelson.encoding.builders.Base32Crockford
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.encoding.test.BaseNEncodingTest
@@ -343,5 +344,13 @@ class Base32CrockfordUnitTest: BaseNEncodingTest() {
     fun givenBase32Crockford_whenLowercaseAndUppercaseChars_thenMatch() {
         assertEquals(Base32.Crockford.CHARS_UPPER, Base32.Crockford.CHARS_LOWER.uppercase())
         assertEquals(Base32.Crockford.CHARS_LOWER, Base32.Crockford.CHARS_UPPER.lowercase())
+    }
+
+    @Test
+    fun givenBase32Hex_whenDecodeEncode_thenReturnsSameValue() {
+        val expected = "AHM6A83HENMP6TS0C9S6YXVE41K6YY10D9TPTW3K41QQCSBJ41T6GS90DHGQMY90CHQPEBG"
+        val decoded = expected.decodeToByteArray(crockford)
+        val rencoded = decoded.encodeToString(crockford)
+        assertEquals(expected, rencoded)
     }
 }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
@@ -18,6 +18,7 @@
 package io.matthewnelson.encoding.base32
 
 import io.matthewnelson.encoding.builders.Base32Default
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.encoding.test.BaseNEncodingTest
@@ -172,5 +173,13 @@ class Base32DefaultUnitTest: BaseNEncodingTest() {
     fun givenBase32Default_whenLowercaseAndUppercaseChars_thenMatch() {
         assertEquals(Base32.Default.CHARS_UPPER, Base32.Default.CHARS_LOWER.uppercase())
         assertEquals(Base32.Default.CHARS_LOWER, Base32.Default.CHARS_UPPER.lowercase())
+    }
+
+    @Test
+    fun givenBase32Default_whenDecodeEncode_thenReturnsSameValue() {
+        val expected = "OBTDFCGTEKTGXPVR23DA7YFDEB5IZGLEHJH5GIIVBKGL5S2HNNRQ===="
+        val decoded = expected.decodeToByteArray(base32Default)
+        val rencoded = decoded.encodeToString(base32Default)
+        assertEquals(expected, rencoded)
     }
 }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
@@ -40,6 +40,23 @@ class Base32DefaultUnitTest: BaseNEncodingTest() {
 
     override val decodeSuccessDataSet: Set<Data<String, ByteArray>> = setOf(
         decodeSuccessHelloWorld,
+        Data(
+            raw = "KNQWY5DFMRPV76DEF2232QQS4NFDHX7K33NZK5K3K7AWZVWK7ZU5DAO32PEYH5ERWNGCOHXOO5LBGXJYMBZAOHSHJ4AP5H6NWGRVGZI=",
+            expected = ("53 61 6c 74 65 64 5f 5f f8 64 2e b5 bd 42 12 e3 4a 33 df ea de db 95 75 5b 57 c1 " +
+                    "6c d6 ca fe 69 d1 81 db d3 c9 83 f4 91 b3 4c 27 1e ee 77 56 13 5d 38 60 72 07 1e 47 " +
+                    "4f 00 fe 9f cd b1 a3 53 65").decodeHexToByteArray()
+        ),
+        Data(
+            raw = "KNQWY5DFMRPV7RXZCOJOT3QZ3KFMCGGJNSPKK3O3V53JPXIV2LNFYV35OUOF42NPUWHGLQGHH2QIO===",
+            expected = ("53 61 6c 74 65 64 5f 5f c6 f9 13 92 e9 ee 19 da 8a c1 18 c9 6c 9e a5 " +
+                    "6d db af 76 97 dd 15 d2 da 5c 57 7d 75 1c 5e 69 af a5 8e 65 c0 c7 3e a0 " +
+                    "87").decodeHexToByteArray()
+        ),
+        Data(
+            raw = "KNQWY5DFMRPV744USBXPVHIQ6GY57YAPIAKQCOUX5QPUROTWVWUQ====",
+            expected = ("53 61 6c 74 65 64 5f 5f f3 94 90 6e fa 9d 10 f1 b1 df e0 0f 40 15 01 " +
+                    "3a 97 ec 1f 48 ba 76 ad a9").decodeHexToByteArray()
+        ),
         Data(raw = "========", expected = ByteArray(0), message = "Decoding a String containing only padding '=' should return an empty ByteArray"),
         Data(raw = "MY======", expected = "f".encodeToByteArray()),
         Data(raw = "MY", expected = "f".encodeToByteArray(), message = "Stripped padding should decode"),

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
@@ -18,6 +18,7 @@
 package io.matthewnelson.encoding.base32
 
 import io.matthewnelson.encoding.builders.Base32Hex
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.encoding.test.BaseNEncodingTest
@@ -173,5 +174,13 @@ class Base32HexUnitTest: BaseNEncodingTest() {
     fun givenBase32Hex_whenLowercaseAndUppercaseChars_thenMatch() {
         assertEquals(Base32.Hex.CHARS_UPPER, Base32.Hex.CHARS_LOWER.uppercase())
         assertEquals(Base32.Hex.CHARS_LOWER, Base32.Hex.CHARS_UPPER.lowercase())
+    }
+
+    @Test
+    fun givenBase32Hex_whenDecodeEncode_thenReturnsSameValue() {
+        val expected = "AHK6A83HELKM6QP0C9P6UTRE41J6UU10D9QMQS3J41NNCPBI41Q6GP90DHGNKU90CHNMEBG="
+        val decoded = expected.decodeToByteArray(base32Hex)
+        val rencoded = decoded.encodeToString(base32Hex)
+        assertEquals(expected, rencoded)
     }
 }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
@@ -41,6 +41,23 @@ class Base32HexUnitTest: BaseNEncodingTest() {
 
     override val decodeSuccessDataSet: Set<Data<String, ByteArray>> = setOf(
         decodeSuccessHelloWorld,
+        Data(
+            raw = "ADGMOT35CHFLVU345QQRQGGISD537NVARRDPATARAV0MPLMAVPKT30ERQF4O7T4HMD62E7NEETB16N9OC1P0E7I79S0FT7UDM6HL6P8=",
+            expected = ("53 61 6c 74 65 64 5f 5f f8 64 2e b5 bd 42 12 e3 4a 33 df ea de db 95 75 5b 57 c1 " +
+                    "6c d6 ca fe 69 d1 81 db d3 c9 83 f4 91 b3 4c 27 1e ee 77 56 13 5d 38 60 72 07 1e 47 " +
+                    "4f 00 fe 9f cd b1 a3 53 65").decodeHexToByteArray()
+        ),
+        Data(
+            raw = "ADGMOT35CHFLVHNP2E9EJRGPRA5C2669DIFAARERLTR9FN8LQBD5OLRTEKE5SQDFKM76BG677QG8E===",
+            expected = ("53 61 6c 74 65 64 5f 5f c6 f9 13 92 e9 ee 19 da 8a c1 18 c9 6c 9e a5 " +
+                    "6d db af 76 97 dd 15 d2 da 5c 57 7d 75 1c 5e 69 af a5 8e 65 c0 c7 3e a0 " +
+                    "87").decodeHexToByteArray()
+        ),
+        Data(
+            raw = "ADGMOT35CHFLVSSKI1NFL78GU6OTVO0F80AG2EKNTGFKHEJMLMKG====",
+            expected = ("53 61 6c 74 65 64 5f 5f f3 94 90 6e fa 9d 10 f1 b1 df e0 0f 40 15 01 " +
+                    "3a 97 ec 1f 48 ba 76 ad a9").decodeHexToByteArray()
+        ),
         Data(raw = "======", expected = ByteArray(0), message = "Decoding a String containing only padding '=' should return an empty ByteArray"),
         Data(raw = "CO======", expected = "f".encodeToByteArray()),
         Data(raw = "CO", expected = "f".encodeToByteArray(), message = "Stripped padding should decode"),

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64DefaultUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64DefaultUnitTest.kt
@@ -18,10 +18,12 @@
 package io.matthewnelson.encoding.base64
 
 import io.matthewnelson.encoding.builders.Base64
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.encoding.test.BaseNEncodingTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class Base64DefaultUnitTest: BaseNEncodingTest() {
 
@@ -158,4 +160,12 @@ class Base64DefaultUnitTest: BaseNEncodingTest() {
         checkUniversalEncoderParameters()
     }
 
+    @Test
+    fun givenBase64_whenDecodeEncode_thenReturnsSameValue() {
+        val expected = "U2FsdGVkX1/4ZC61vUIS40oz3+re25V1W1fBbNbK/mnRgdvTyYP0kbNMJx7ud1YTXThgcgceR08A/p/NsaNTZQ=="
+        val base64 = Base64()
+        val decoded = expected.decodeToByteArray(base64)
+        val rencoded = decoded.encodeToString(base64)
+        assertEquals(expected, rencoded)
+    }
 }

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64DefaultUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64DefaultUnitTest.kt
@@ -27,17 +27,6 @@ import kotlin.test.assertEquals
 
 class Base64DefaultUnitTest: BaseNEncodingTest() {
 
-    companion object {
-        fun String.decodeHexToByteArray(): ByteArray {
-            val newString = replace(" ", "")
-            check(newString.length % 2 == 0) { "Hex must have an even length" }
-
-            return newString.chunked(2)
-                .map { it.toInt(16).toByte() }
-                .toByteArray()
-        }
-    }
-
     override val decodeFailureDataSet: Set<Data<String, Any?>> = setOf(
         Data("SGVsbG8gV29ybGQ^", expected = null, message = "Character '^' should return null")
     )

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64UrlSafeUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64UrlSafeUnitTest.kt
@@ -20,9 +20,11 @@ package io.matthewnelson.encoding.base64
 import io.matthewnelson.encoding.test.BaseNEncodingTest
 import io.matthewnelson.encoding.base64.Base64DefaultUnitTest.Companion.decodeHexToByteArray
 import io.matthewnelson.encoding.builders.Base64
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class Base64UrlSafeUnitTest: BaseNEncodingTest() {
 
@@ -177,4 +179,11 @@ class Base64UrlSafeUnitTest: BaseNEncodingTest() {
         checkUniversalEncoderParameters()
     }
 
+    @Test
+    fun givenBase64UrlSafe_whenDecodeEncode_thenReturnsSameValue() {
+        val expected = "U2FsdGVkX1_4ZC61vUIS40oz3-re25V1W1fBbNbK_mnRgdvTyYP0kbNMJx7ud1YTXThgcgceR08A_p_NsaNTZQ=="
+        val decoded = expected.decodeToByteArray(base64UrlSafe)
+        val rencoded = decoded.encodeToString(base64UrlSafe)
+        assertEquals(expected, rencoded)
+    }
 }

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64UrlSafeUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64UrlSafeUnitTest.kt
@@ -18,7 +18,6 @@
 package io.matthewnelson.encoding.base64
 
 import io.matthewnelson.encoding.test.BaseNEncodingTest
-import io.matthewnelson.encoding.base64.Base64DefaultUnitTest.Companion.decodeHexToByteArray
 import io.matthewnelson.encoding.builders.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull

--- a/library/encoding-test/src/commonMain/kotlin/io/matthewnelson/encoding/test/BaseNEncodingTest.kt
+++ b/library/encoding-test/src/commonMain/kotlin/io/matthewnelson/encoding/test/BaseNEncodingTest.kt
@@ -15,11 +15,27 @@
  **/
 package io.matthewnelson.encoding.test
 
+import kotlin.jvm.JvmStatic
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 abstract class BaseNEncodingTest {
+
+    companion object {
+        /**
+         * Converts Bytes in hexidecimal format from https://cryptii.com to a ByteArray.
+         * */
+        @JvmStatic
+        fun String.decodeHexToByteArray(): ByteArray {
+            val newString = replace(" ", "")
+            check(newString.length % 2 == 0) { "Hex must have an even length" }
+
+            return newString.chunked(2)
+                .map { it.toInt(16).toByte() }
+                .toByteArray()
+        }
+    }
 
     protected data class Data<Data: Any, Expected: Any?>(
         val raw: Data,


### PR DESCRIPTION
Closes #92 

Adds tests to all implementations for decoding and re-encoding to check for any discrepancies in expected output.