### PR TITLE
Add random data encode/decode test

### DIFF
--- a/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
+++ b/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
@@ -189,4 +189,9 @@ class Base16UnitTest: BaseNEncodingTest() {
         val rencoded = decoded.encodeToString(base16)
         assertEquals(expected, rencoded)
     }
+
+    @Test
+    fun givenBase12_whenEncodeDecodeRandomData_thenBytesMatch() {
+        checkRandomData()
+    }
 }

--- a/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
+++ b/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
@@ -194,4 +194,10 @@ class Base16UnitTest: BaseNEncodingTest() {
     fun givenBase16_whenEncodeDecodeRandomData_thenBytesMatch() {
         checkRandomData()
     }
+
+    @Test
+    fun givenBase16Lowercase_whenEncodeDecodeRandomData_thenBytesMatch() {
+        base16 = Base16 { encodeToLowercase = true }
+        checkRandomData()
+    }
 }

--- a/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
+++ b/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
@@ -191,7 +191,7 @@ class Base16UnitTest: BaseNEncodingTest() {
     }
 
     @Test
-    fun givenBase12_whenEncodeDecodeRandomData_thenBytesMatch() {
+    fun givenBase16_whenEncodeDecodeRandomData_thenBytesMatch() {
         checkRandomData()
     }
 }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
@@ -364,10 +364,15 @@ class Base32CrockfordUnitTest: BaseNEncodingTest() {
     }
 
     @Test
-    fun givenBase32Hex_whenDecodeEncode_thenReturnsSameValue() {
+    fun givenBase32Crockford_whenDecodeEncode_thenReturnsSameValue() {
         val expected = "AHM6A83HENMP6TS0C9S6YXVE41K6YY10D9TPTW3K41QQCSBJ41T6GS90DHGQMY90CHQPEBG"
         val decoded = expected.decodeToByteArray(crockford)
         val rencoded = decoded.encodeToString(crockford)
         assertEquals(expected, rencoded)
+    }
+
+    @Test
+    fun givenBase32Crockford_whenEncodeDecodeRandomData_thenBytesMatch() {
+        checkRandomData()
     }
 }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
@@ -375,4 +375,11 @@ class Base32CrockfordUnitTest: BaseNEncodingTest() {
     fun givenBase32Crockford_whenEncodeDecodeRandomData_thenBytesMatch() {
         checkRandomData()
     }
+
+    @Test
+    fun givenBase32CrockfordLowercase_whenEncodeDecodeRandomData_thenBytesMatch() {
+        crockford = Base32Crockford { encodeToLowercase = true }
+        checkRandomData()
+    }
+
 }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
@@ -204,4 +204,11 @@ class Base32DefaultUnitTest: BaseNEncodingTest() {
     fun givenBase32Default_whenEncodeDecodeRandomData_thenBytesMatch() {
         checkRandomData()
     }
+
+    @Test
+    fun givenBase32DefaultLowercase_whenEncodeDecodeRandomData_thenBytesMatch() {
+        base32Default = Base32Default { encodeToLowercase = true }
+        checkRandomData()
+    }
+
 }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
@@ -199,4 +199,9 @@ class Base32DefaultUnitTest: BaseNEncodingTest() {
         val rencoded = decoded.encodeToString(base32Default)
         assertEquals(expected, rencoded)
     }
+
+    @Test
+    fun givenBase32Default_whenEncodeDecodeRandomData_thenBytesMatch() {
+        checkRandomData()
+    }
 }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
@@ -205,4 +205,10 @@ class Base32HexUnitTest: BaseNEncodingTest() {
     fun givenBase32Hex_whenEncodeDecodeRandomData_thenBytesMatch() {
         checkRandomData()
     }
+
+    @Test
+    fun givenBase32HexLowercase_whenEncodeDecodeRandomData_thenBytesMatch() {
+        base32Hex = Base32Hex { encodeToLowercase = true }
+        checkRandomData()
+    }
 }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
@@ -200,4 +200,9 @@ class Base32HexUnitTest: BaseNEncodingTest() {
         val rencoded = decoded.encodeToString(base32Hex)
         assertEquals(expected, rencoded)
     }
+
+    @Test
+    fun givenBase32Hex_whenEncodeDecodeRandomData_thenBytesMatch() {
+        checkRandomData()
+    }
 }

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64DefaultUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64DefaultUnitTest.kt
@@ -157,4 +157,9 @@ class Base64DefaultUnitTest: BaseNEncodingTest() {
         val rencoded = decoded.encodeToString(base64)
         assertEquals(expected, rencoded)
     }
+
+    @Test
+    fun givenBase64_whenEncodeDecodeRandomData_thenBytesMatch() {
+        checkRandomData()
+    }
 }

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64UrlSafeUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64UrlSafeUnitTest.kt
@@ -185,4 +185,9 @@ class Base64UrlSafeUnitTest: BaseNEncodingTest() {
         val rencoded = decoded.encodeToString(base64UrlSafe)
         assertEquals(expected, rencoded)
     }
+
+    @Test
+    fun givenBase64UrlSafe_whenEncodeDecodeRandomData_thenBytesMatch() {
+        checkRandomData()
+    }
 }

--- a/library/encoding-test/src/commonMain/kotlin/io/matthewnelson/encoding/test/BaseNEncodingTest.kt
+++ b/library/encoding-test/src/commonMain/kotlin/io/matthewnelson/encoding/test/BaseNEncodingTest.kt
@@ -16,6 +16,7 @@
 package io.matthewnelson.encoding.test
 
 import kotlin.jvm.JvmStatic
+import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -160,5 +161,15 @@ abstract class BaseNEncodingTest {
             actual = encode(ByteArray(0)),
             message = "Encoding empty ByteArray should return an empty String"
         )
+    }
+
+    protected fun checkRandomData() {
+        val bytes = Random.nextBytes(20_000)
+        val encoded = encode(bytes)
+        val decoded = decode(encoded)!!
+
+        bytes.forEachIndexed { index, byte ->
+            assertEquals(byte, decoded[index])
+        }
     }
 }

--- a/library/encoding-test/src/commonMain/kotlin/io/matthewnelson/encoding/test/BaseNEncodingTest.kt
+++ b/library/encoding-test/src/commonMain/kotlin/io/matthewnelson/encoding/test/BaseNEncodingTest.kt
@@ -168,6 +168,7 @@ abstract class BaseNEncodingTest {
         val encoded = encode(bytes)
         val decoded = decode(encoded)!!
 
+        assertEquals(bytes.size, decoded.size)
         bytes.forEachIndexed { index, byte ->
             assertEquals(byte, decoded[index])
         }

--- a/library/encoding-test/src/commonMain/kotlin/io/matthewnelson/encoding/test/BaseNEncodingTest.kt
+++ b/library/encoding-test/src/commonMain/kotlin/io/matthewnelson/encoding/test/BaseNEncodingTest.kt
@@ -164,7 +164,7 @@ abstract class BaseNEncodingTest {
     }
 
     protected fun checkRandomData() {
-        val bytes = Random.nextBytes(20_000)
+        val bytes = Random.nextBytes(1_000_000)
         val encoded = encode(bytes)
         val decoded = decode(encoded)!!
 


### PR DESCRIPTION
Closes #94 

Adds a test for all implementations which encodes a copious amount of random bytes, decodes what was encoded, and then verifies that each byte of the decoded output matches the original bytes.