### PR TITLE
Update dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 binaryCompat = "0.12.1"
-configuration = "0.1.0-alpha02"
+configuration = "0.1.0-beta01"
 gradleVersions = "0.46.0"
 kotlin = "1.8.0"
 publish = "0.24.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-binaryCompat = "0.12.1"
+binaryCompat = "0.13.0"
 configuration = "0.1.0-beta01"
 gradleVersions = "0.46.0"
 kotlin = "1.8.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 binaryCompat = "0.12.1"
 configuration = "0.1.0-beta01"
 gradleVersions = "0.46.0"
-kotlin = "1.8.0"
+kotlin = "1.8.10"
 publish = "0.24.0"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,5 +4,5 @@ zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 
 # https://gradle.org/release-checksums/
-distributionSha256Sum=312eb12875e1747e05c2f81a4789902d7e4ec5defbd1eefeaccc08acf096505d
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionSha256Sum=948d1e4ccc2f6ae36cbfa087d827aaca51403acae5411e664a6000bb47946f22
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip


### PR DESCRIPTION
Closes #99 

This PR updates the following dependencies:
 - Gradle Wrapper -> `8.0.1`
 - kmp-configuration plugin -> `0.1.0-beta01`
 - Kotlin -> `1.8.10`
 - binary compat plugin -> `0.13.0`