### PR TITLE
Adds ability to `flush` an `EncoderDecoder.Feed` to process multiple inputs

### DIFF
--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -331,6 +331,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
                 @Throws(EncodingException::class)
                 override fun doFinalProtected() {
                     buffer.finalize()
+                    isCheckSymbolSet = false
                 }
             }
         }
@@ -379,6 +380,9 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
                             out.output(symbol.uppercaseChar())
                         }
                     }
+
+                    outCount = 0
+                    outputHyphenOnNext = false
                 }
             }
         }

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -26,6 +26,7 @@ public abstract class io/matthewnelson/encoding/core/Decoder$Feed : io/matthewne
 	public final fun close ()V
 	public final fun consume (C)V
 	protected abstract fun consumeProtected (C)V
+	public final fun flush ()V
 	public final fun isClosed ()Z
 	public final fun toString ()Ljava/lang/String;
 }
@@ -56,6 +57,7 @@ public abstract class io/matthewnelson/encoding/core/Encoder$Feed : io/matthewne
 	public final fun consume (B)V
 	protected abstract fun consumeProtected (B)V
 	protected abstract fun doFinalProtected ()V
+	public final fun flush ()V
 	public final fun isClosed ()Z
 	public final fun toString ()Ljava/lang/String;
 }
@@ -109,6 +111,7 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Feed {
 	public abstract fun close ()V
 	public final fun doFinal ()V
 	protected abstract fun doFinalProtected ()V
+	public abstract fun flush ()V
 	public final fun getConfig ()Lio/matthewnelson/encoding/core/EncoderDecoder$Config;
 	public abstract fun isClosed ()Z
 }

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -85,6 +85,7 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	protected abstract fun decodeOutMaxSizeOrFailProtected (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 	protected abstract fun decodeOutMaxSizeProtected (J)J
 	public final fun encodeOutSize (J)J
+	public final fun encodeOutSize (JB)J
 	protected abstract fun encodeOutSizeProtected (J)J
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/-Feed.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/-Feed.kt
@@ -29,9 +29,6 @@ import io.matthewnelson.encoding.core.EncoderDecoder.Feed
  *    exception and the feed is still open.
  *  - Calling [Feed.close] if [block] **DID** throw an
  *    exception.
- *
- * @sample [io.matthewnelson.encoding.core.internal.encode]
- * @sample [io.matthewnelson.encoding.core.internal.decode]
  * */
 @ExperimentalEncodingApi
 @OptIn(ExperimentalContracts::class)

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -132,10 +132,32 @@ public sealed class Decoder<C: EncoderDecoder.Config>(public val config: C) {
             }
         }
 
+        /**
+         * Flushes the buffered input and performs any final decoding
+         * operations without closing the [Feed].
+         *
+         * @see [EncoderDecoder.Feed.flush]
+         * @throws [EncodingException] if [isClosed] is true, or if
+         *   there was an error decoding.
+         * */
         @ExperimentalEncodingApi
-        final override fun close() { isClosed = true }
-        final override fun isClosed(): Boolean = isClosed
-        final override fun toString(): String = "${this@Decoder}.Decoder.Feed@${hashCode()}"
+        @Throws(EncodingException::class)
+        public final override fun flush() {
+            if (isClosed) throw closedException()
+
+            try {
+                doFinalProtected()
+                isPaddingSet = false
+            } catch (t: Throwable) {
+                close()
+                throw t
+            }
+        }
+
+        @ExperimentalEncodingApi
+        public final override fun close() { isClosed = true }
+        public final override fun isClosed(): Boolean = isClosed
+        public final override fun toString(): String = "${this@Decoder}.Decoder.Feed@${hashCode()}"
 
         @Throws(EncodingException::class)
         protected abstract fun consumeProtected(input: Char)

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -82,7 +82,6 @@ public sealed class Decoder<C: EncoderDecoder.Config>(public val config: C) {
      * @see [use]
      * @see [EncoderDecoder.Feed]
      * @see [EncoderDecoder.Feed.doFinal]
-     * @sample [io.matthewnelson.encoding.base16.Base16.newDecoderFeedProtected]
      * */
     public abstract inner class Feed
     @ExperimentalEncodingApi

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
@@ -79,7 +79,6 @@ public sealed class Encoder<C: EncoderDecoder.Config>(config: C): Decoder<C>(con
      * @see [use]
      * @see [EncoderDecoder.Feed]
      * @see [EncoderDecoder.Feed.doFinal]
-     * @sample [io.matthewnelson.encoding.base16.Base16.newEncoderFeedProtected]
      * */
     public abstract inner class Feed
     @ExperimentalEncodingApi

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -82,7 +82,23 @@ constructor(config: C): Encoder<C>(config) {
          *   the calculated size exceeded [Long.MAX_VALUE].
          * */
         @Throws(EncodingSizeException::class)
-        public fun encodeOutSize(unEncodedSize: Long): Long {
+        public fun encodeOutSize(unEncodedSize: Long): Long = encodeOutSize(unEncodedSize, lineBreakInterval)
+
+        /**
+         * Pre-calculates and returns the size of the output, after encoding
+         * would occur, based off of the [Config] options set and expressed
+         * [lineBreakInterval].
+         *
+         * Will always return a value greater than or equal to 0.
+         *
+         * @param [unEncodedSize] The size of the data which is to be encoded.
+         * @param [lineBreakInterval] The interval at which linebreaks are to
+         *   be inserted.
+         * @throws [EncodingSizeException] If [unEncodedSize] is negative, or
+         *   the calculated size exceeded [Long.MAX_VALUE].
+         * */
+        @Throws(EncodingSizeException::class)
+        public fun encodeOutSize(unEncodedSize: Long, lineBreakInterval: Byte): Long {
             if (unEncodedSize < 0L) {
                 throw EncodingSizeException("unEncodedSize cannot be negative")
             }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -32,7 +32,6 @@ import kotlin.jvm.JvmStatic
  * @see [Feed]
  * @see [Encoder]
  * @see [Decoder]
- * @sample [io.matthewnelson.encoding.base16.Base16]
  * */
 public abstract class EncoderDecoder<C: EncoderDecoder.Config>
 @ExperimentalEncodingApi
@@ -54,7 +53,6 @@ constructor(config: C): Encoder<C>(config) {
      *   padding the encoded output; **NOT** "if padding should be
      *   used". If the encoding specification does not use padding,
      *   pass `null`.
-     * @sample [io.matthewnelson.encoding.base16.Base16.Config]
      * */
     public abstract class Config
     @ExperimentalEncodingApi

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/FeedBuffer.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/FeedBuffer.kt
@@ -34,7 +34,6 @@ import kotlin.jvm.JvmStatic
  * @see [truncatedInputEncodingException]
  * @throws [IllegalArgumentException] if [blockSize] is less
  *   than or equal to 0
- * @sample [io.matthewnelson.encoding.base16.Base16.DecodingBuffer]
  * */
 public abstract class FeedBuffer
 @Throws(IllegalArgumentException::class)

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
@@ -197,6 +197,30 @@ class EncoderDecoderFeedUnitTest {
     }
 
     @Test
+    fun givenDecoderFeed_whenFlushed_thenFeedIsReset() {
+        var invocations = 0
+        var output: Byte = 0
+        val feed = TestEncoderDecoder(TestConfig(isLenient = true, paddingChar = '=')).newDecoderFeed {
+            invocations++
+            output = it
+        }
+
+        feed.consume('g')
+        feed.consume('=')
+
+        assertEquals(1, invocations)
+        assertEquals(Byte.MAX_VALUE, output)
+
+        feed.flush()
+        assertEquals(2, invocations)
+        assertEquals(Byte.MIN_VALUE, output)
+
+        feed.consume('g')
+        assertEquals(3, invocations)
+        assertEquals(Byte.MAX_VALUE, output)
+    }
+
+    @Test
     fun givenEncoderFeed_whenLineBreakExpressedInConfig_thenNewLinesAreAutomaticallyAppended() {
         val encoder = TestEncoderDecoder(
             config = TestConfig(
@@ -256,5 +280,28 @@ class EncoderDecoderFeedUnitTest {
             assertEquals(12, sb.length)
             assertTrue(sb.toString().lines().size == 2)
         }
+    }
+
+    @Test
+    fun givenEncoderFeed_whenFlushed_thenFeedIsReset() {
+        var invocations = 0
+        var output = ' '
+        val feed = TestEncoderDecoder(TestConfig(isLenient = true, paddingChar = '=')).newEncoderFeed {
+            invocations++
+            output = it
+        }
+
+        feed.consume(5)
+
+        assertEquals(1, invocations)
+        assertEquals(Char.MAX_VALUE, output)
+
+        feed.flush()
+        assertEquals(2, invocations)
+        assertEquals(Char.MIN_VALUE, output)
+
+        feed.consume(5)
+        assertEquals(3, invocations)
+        assertEquals(Char.MAX_VALUE, output)
     }
 }


### PR DESCRIPTION
Closes #108 

Also, Adds a new function to `EncoderDecoder.Config` for pre-calculating the encode output size by expressing a custom `lineBreakInterval`