### PR TITLE
Rework static instances to have companion objects extend `EncoderDecoder`

### DIFF
--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -10,11 +10,10 @@ public final class io/matthewnelson/encoding/base16/Base16 : io/matthewnelson/en
 	public static final field CHARS_LOWER Ljava/lang/String;
 	public static final field CHARS_UPPER Ljava/lang/String;
 	public static final field Companion Lio/matthewnelson/encoding/base16/Base16$Companion;
-	public static final field INSTANCE Lio/matthewnelson/encoding/base16/Base16;
 	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Config;)V
 }
 
-public final class io/matthewnelson/encoding/base16/Base16$Companion {
+public final class io/matthewnelson/encoding/base16/Base16$Companion : io/matthewnelson/encoding/core/EncoderDecoder {
 }
 
 public final class io/matthewnelson/encoding/base16/Base16$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -43,14 +43,17 @@ import kotlin.jvm.JvmSynthetic
  *     val bytes = text.encodeToByteArray()
  *     val encoded = bytes.encodeToString(base16)
  *     println(encoded) // 48656c6c6f20576f726c6421
- *     val decoded = encoded.decodeToByteArray(base16).decodeToString()
+ *
+ *     // Alternatively, use the static implementaton instead of
+ *     // configuring your own settings.
+ *     val decoded = encoded.decodeToByteArray(Base16).decodeToString()
  *     assertEquals(text, decoded)
  *
  * @see [io.matthewnelson.encoding.builders.Base16]
  * @see [Base16.Config]
  * @see [Base16.CHARS_UPPER]
  * @see [Base16.CHARS_LOWER]
- * @see [Base16.INSTANCE]
+ * @see [Base16.Companion]
  * @see [EncoderDecoder]
  * @see [Decoder.decodeToByteArray]
  * @see [Decoder.decodeToByteArrayOrNull]
@@ -116,7 +119,22 @@ public class Base16(config: Base16.Config): EncoderDecoder<Base16.Config>(config
         }
     }
 
-    public companion object {
+    /**
+     * Doubles as a static implementation with default settings
+     * and a lineBreakInterval of 64.
+     *
+     * e.g.
+     *
+     *     val encoded = "Hello World!"
+     *         .encodeToByteArray()
+     *         .encodeToString(Base16)
+     *
+     *     println(encoded) // 48656c6c6f20576f726c6421
+     *
+     * */
+    public companion object: EncoderDecoder<Base16.Config>(
+        config = Base16ConfigBuilder().apply { lineBreakInterval = 64 }.build()
+    ) {
 
         /**
          * Uppercase Base16 encoding characters.
@@ -128,11 +146,14 @@ public class Base16(config: Base16.Config): EncoderDecoder<Base16.Config>(config
          * */
         public const val CHARS_LOWER: String = "0123456789abcdef"
 
-        /**
-         * A static instance with a lineBreakInterval of 64
-         * */
-        @JvmField
-        public val INSTANCE: Base16 = Base16 { lineBreakInterval = 64 }
+        private val DELEGATE = Base16(config)
+        protected override fun name(): String = DELEGATE.name()
+        protected override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Base16.Config>.Feed {
+            return DELEGATE.newDecoderFeedProtected(out)
+        }
+        protected override fun newEncoderFeedProtected(out: OutFeed): Encoder<Base16.Config>.Feed {
+            return DELEGATE.newEncoderFeedProtected(out)
+        }
     }
 
     protected override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Config>.Feed {

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -67,11 +67,10 @@ public final class io/matthewnelson/encoding/base32/Base32$Crockford : io/matthe
 	public static final field CHARS_LOWER Ljava/lang/String;
 	public static final field CHARS_UPPER Ljava/lang/String;
 	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Crockford$Companion;
-	public static final field INSTANCE Lio/matthewnelson/encoding/base32/Base32$Crockford;
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;)V
 }
 
-public final class io/matthewnelson/encoding/base32/Base32$Crockford$Companion {
+public final class io/matthewnelson/encoding/base32/Base32$Crockford$Companion : io/matthewnelson/encoding/core/EncoderDecoder {
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Crockford$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
@@ -86,11 +85,10 @@ public final class io/matthewnelson/encoding/base32/Base32$Default : io/matthewn
 	public static final field CHARS_LOWER Ljava/lang/String;
 	public static final field CHARS_UPPER Ljava/lang/String;
 	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Default$Companion;
-	public static final field INSTANCE Lio/matthewnelson/encoding/base32/Base32$Default;
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Config;)V
 }
 
-public final class io/matthewnelson/encoding/base32/Base32$Default$Companion {
+public final class io/matthewnelson/encoding/base32/Base32$Default$Companion : io/matthewnelson/encoding/core/EncoderDecoder {
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Default$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
@@ -103,11 +101,10 @@ public final class io/matthewnelson/encoding/base32/Base32$Hex : io/matthewnelso
 	public static final field CHARS_LOWER Ljava/lang/String;
 	public static final field CHARS_UPPER Ljava/lang/String;
 	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Hex$Companion;
-	public static final field INSTANCE Lio/matthewnelson/encoding/base32/Base32$Hex;
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;)V
 }
 
-public final class io/matthewnelson/encoding/base32/Base32$Hex$Companion {
+public final class io/matthewnelson/encoding/base32/Base32$Hex$Companion : io/matthewnelson/encoding/core/EncoderDecoder {
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Hex$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -60,14 +60,17 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
      *     val bytes = text.encodeToByteArray()
      *     val encoded = bytes.encodeToString(base32Crockford)
      *     println(encoded) // 91JPR-V3F41-BPYWK-CCGGG~
-     *     val decoded = encoded.decodeToByteArray(base32Crockford).decodeToString()
+     *
+     *     // Alternatively, use the static implementaton instead of
+     *     // configuring your own settings.
+     *     val decoded = encoded.decodeToByteArray(Base32.Crockford).decodeToString()
      *     assertEquals(text, decoded)
      *
      * @see [Base32Crockford]
      * @see [Crockford.Config]
      * @see [Crockford.CHARS_UPPER]
      * @see [Crockford.CHARS_LOWER]
-     * @see [Crockford.INSTANCE]
+     * @see [Crockford.Companion]
      * @see [EncoderDecoder]
      * */
     public class Crockford(config: Crockford.Config): Base32<Crockford.Config>(config) {
@@ -192,7 +195,22 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             }
         }
 
-        public companion object {
+        /**
+         * Doubles as a static implementation with default settings
+         * and a hyphenInterval of 4.
+         *
+         * e.g.
+         *
+         *     val encoded = "Hello World!"
+         *         .encodeToByteArray()
+         *         .encodeToString(Base32.Crockford)
+         *
+         *     println(encoded) // 91JP-RV3F-41BP-YWKC-CGGG
+         *
+         * */
+        public companion object: EncoderDecoder<Base32.Crockford.Config>(
+            config = Base32CrockfordConfigBuilder().apply { hyphenInterval = 4 }.build()
+        ) {
 
             /**
              * Uppercase Base32 Crockford encoding characters.
@@ -204,11 +222,14 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
              * */
             public const val CHARS_LOWER: String = "0123456789abcdefghjkmnpqrstvwxyz"
 
-            /**
-             * A static instance with a hyphenInterval of 4
-             * */
-            @JvmField
-            public val INSTANCE: Base32.Crockford = Base32Crockford { hyphenInterval = 4 }
+            private val DELEGATE = Crockford(config)
+            protected override fun name(): String = DELEGATE.name()
+            protected override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Crockford.Config>.Feed {
+                return DELEGATE.newDecoderFeedProtected(out)
+            }
+            protected override fun newEncoderFeedProtected(out: OutFeed): Encoder<Crockford.Config>.Feed {
+                return DELEGATE.newEncoderFeedProtected(out)
+            }
         }
 
         protected override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Crockford.Config>.Feed {
@@ -422,14 +443,17 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
      *     val bytes = text.encodeToByteArray()
      *     val encoded = bytes.encodeToString(base32Default)
      *     println(encoded) // JBSWY3DPEBLW64TMMQQQ====
-     *     val decoded = encoded.decodeToByteArray(base32Default).decodeToString()
+     *
+     *     // Alternatively, use the static implementaton instead of
+     *     // configuring your own settings.
+     *     val decoded = encoded.decodeToByteArray(Base32.Default).decodeToString()
      *     assertEquals(text, decoded)
      *
      * @see [Base32Default]
      * @see [Default.Config]
      * @see [Default.CHARS_UPPER]
      * @see [Default.CHARS_LOWER]
-     * @see [Default.INSTANCE]
+     * @see [Default.Companion]
      * @see [EncoderDecoder]
      * */
     public class Default(config: Default.Config): Base32<Default.Config>(config) {
@@ -488,7 +512,22 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             }
         }
 
-        public companion object {
+        /**
+         * Doubles as a static implementation with default settings
+         * and a lineBreakInterval of 64.
+         *
+         * e.g.
+         *
+         *     val encoded = "Hello World!"
+         *         .encodeToByteArray()
+         *         .encodeToString(Base32.Default)
+         *
+         *     println(encoded) // JBSWY3DPEBLW64TMMQQQ====
+         *
+         * */
+        public companion object: EncoderDecoder<Base32.Default.Config>(
+            config = Base32DefaultConfigBuilder().apply { lineBreakInterval = 64 }.build()
+        ) {
 
             /**
              * Uppercase Base32 Default encoding characters.
@@ -500,11 +539,14 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
              * */
             public const val CHARS_LOWER: String = "abcdefghijklmnopqrstuvwxyz234567"
 
-            /**
-             * A static instance with a lineBreakInterval of 64
-             * */
-            @JvmField
-            public val INSTANCE: Base32.Default = Base32Default { lineBreakInterval = 64 }
+            private val DELEGATE = Default(config)
+            protected override fun name(): String = DELEGATE.name()
+            protected override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Default.Config>.Feed {
+                return DELEGATE.newDecoderFeedProtected(out)
+            }
+            protected override fun newEncoderFeedProtected(out: OutFeed): Encoder<Default.Config>.Feed {
+                return DELEGATE.newEncoderFeedProtected(out)
+            }
         }
 
         protected override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Default.Config>.Feed {
@@ -597,14 +639,17 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
      *     val bytes = text.encodeToByteArray()
      *     val encoded = bytes.encodeToString(base32Hex)
      *     println(encoded) // 91IMOR3F41BMUSJCCGGG====
-     *     val decoded = encoded.decodeToByteArray(base32Hex).decodeToString()
+     *
+     *     // Alternatively, use the static implementaton instead of
+     *     // configuring your own settings.
+     *     val decoded = encoded.decodeToByteArray(Base32.Hex).decodeToString()
      *     assertEquals(text, decoded)
      *
      * @see [Base32Hex]
      * @see [Hex.Config]
      * @see [Hex.CHARS_UPPER]
      * @see [Hex.CHARS_LOWER]
-     * @see [Hex.INSTANCE]
+     * @see [Hex.Companion]
      * @see [EncoderDecoder]
      * */
     public class Hex(config: Hex.Config): Base32<Hex.Config>(config) {
@@ -663,7 +708,22 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             }
         }
 
-        public companion object {
+        /**
+         * Doubles as a static implementation with default settings
+         * and a lineBreakInterval of 64.
+         *
+         * e.g.
+         *
+         *     val encoded = "Hello World!"
+         *         .encodeToByteArray()
+         *         .encodeToString(Base32.Hex)
+         *
+         *     println(encoded) // 91IMOR3F41BMUSJCCGGG====
+         *
+         * */
+        public companion object: EncoderDecoder<Base32.Hex.Config>(
+            config = Base32HexConfigBuilder().apply { lineBreakInterval = 64 }.build()
+        ) {
 
             /**
              * Uppercase Base32 Hex encoding characters.
@@ -675,11 +735,14 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
              * */
             public const val CHARS_LOWER: String = "0123456789abcdefghijklmnopqrstuv"
 
-            /**
-             * A static instance with a lineBreakInterval of 64
-             * */
-            @JvmField
-            public val INSTANCE: Base32.Hex = Base32Hex { lineBreakInterval = 64 }
+            private val DELEGATE = Hex(config)
+            override fun name(): String = DELEGATE.name()
+            override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Hex.Config>.Feed {
+                return DELEGATE.newDecoderFeedProtected(out)
+            }
+            override fun newEncoderFeedProtected(out: OutFeed): Encoder<Hex.Config>.Feed {
+                return DELEGATE.newEncoderFeedProtected(out)
+            }
         }
 
         protected override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Hex.Config>.Feed {

--- a/library/encoding-base64/api/encoding-base64.api
+++ b/library/encoding-base64/api/encoding-base64.api
@@ -51,16 +51,14 @@ public final class io/matthewnelson/encoding/base64/Base64$Config : io/matthewne
 	public synthetic fun <init> (ZBZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class io/matthewnelson/encoding/base64/Base64$Default {
+public final class io/matthewnelson/encoding/base64/Base64$Default : io/matthewnelson/encoding/core/EncoderDecoder {
 	public static final field CHARS Ljava/lang/String;
 	public static final field INSTANCE Lio/matthewnelson/encoding/base64/Base64$Default;
-	public static final field INSTANCE Lio/matthewnelson/encoding/base64/Base64;
 }
 
-public final class io/matthewnelson/encoding/base64/Base64$UrlSafe {
+public final class io/matthewnelson/encoding/base64/Base64$UrlSafe : io/matthewnelson/encoding/core/EncoderDecoder {
 	public static final field CHARS Ljava/lang/String;
 	public static final field INSTANCE Lio/matthewnelson/encoding/base64/Base64$UrlSafe;
-	public static final field INSTANCE Lio/matthewnelson/encoding/base64/Base64;
 }
 
 public final class io/matthewnelson/encoding/builders/Base64BuildersKt {

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -49,15 +49,18 @@ import kotlin.jvm.JvmSynthetic
  *     val bytes = text.encodeToByteArray()
  *     val encoded = bytes.encodeToString(base64)
  *     println(encoded) // SGVsbG8gV29ybGQh
- *     val decoded = encoded.decodeToByteArray(base64).decodeToString()
+ *
+ *     // Alternatively, use the static implementaton instead of
+ *     // configuring your own settings.
+ *     val decoded = encoded.decodeToByteArray(Base64.Default).decodeToString()
  *     assertEquals(text, decoded)
  *
  * @see [io.matthewnelson.encoding.builders.Base64]
  * @see [Base64.Config]
  * @see [Default.CHARS]
  * @see [UrlSafe.CHARS]
- * @see [Default.INSTANCE]
- * @see [UrlSafe.INSTANCE]
+ * @see [Default]
+ * @see [UrlSafe]
  * @see [EncoderDecoder]
  * @see [Decoder.decodeToByteArray]
  * @see [Decoder.decodeToByteArrayOrNull]
@@ -132,32 +135,68 @@ public class Base64(config: Base64.Config): EncoderDecoder<Base64.Config>(config
         }
     }
 
-    public object Default {
+    /**
+     * Doubles as a static implementation with default settings
+     * and a lineBreakInterval of 64.
+     *
+     * e.g.
+     *
+     *     val encoded = "Hello World!"
+     *         .encodeToByteArray()
+     *         .encodeToString(Base64.Default)
+     *
+     *     println(encoded) // SGVsbG8gV29ybGQh
+     *
+     * */
+    public object Default: EncoderDecoder<Base64.Config>(
+        config = Base64ConfigBuilder().apply { lineBreakInterval = 64 }.build()
+    ) {
 
         /**
          * Base64 Default encoding characters.
          * */
         public const val CHARS: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-        /**
-         * A static instance with a lineBreakInterval of 64
-         * */
-        @JvmField
-        public val INSTANCE: Base64 = Base64 { lineBreakInterval = 64 }
+        private val DELEGATE = Base64(config)
+        override fun name(): String = DELEGATE.name()
+        override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Base64.Config>.Feed {
+            return DELEGATE.newDecoderFeedProtected(out)
+        }
+        override fun newEncoderFeedProtected(out: OutFeed): Encoder<Base64.Config>.Feed {
+            return DELEGATE.newEncoderFeedProtected(out)
+        }
     }
 
-    public object UrlSafe {
+    /**
+     * Doubles as a static implementation with default settings
+     * and a lineBreakInterval of 64.
+     *
+     * e.g.
+     *
+     *     val encoded = "Hello World!"
+     *         .encodeToByteArray()
+     *         .encodeToString(Base64.UrlSafe)
+     *
+     *     println(encoded) // SGVsbG8gV29ybGQh
+     *
+     * */
+    public object UrlSafe: EncoderDecoder<Base64.Config>(
+        config = Base64ConfigBuilder(Default.config).apply { encodeToUrlSafe = true }.build()
+    ) {
 
         /**
          * Base64 UrlSafe encoding characters.
          * */
         public const val CHARS: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 
-        /**
-         * A static instance with a lineBreakInterval of 64
-         * */
-        @JvmField
-        public val INSTANCE: Base64 = Base64(Default.INSTANCE.config) { encodeToUrlSafe = true }
+        private val DELEGATE = Base64(config)
+        override fun name(): String = DELEGATE.name()
+        override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Base64.Config>.Feed {
+            return DELEGATE.newDecoderFeedProtected(out)
+        }
+        override fun newEncoderFeedProtected(out: OutFeed): Encoder<Base64.Config>.Feed {
+            return DELEGATE.newEncoderFeedProtected(out)
+        }
     }
 
     protected override fun newDecoderFeedProtected(out: Decoder.OutFeed): Decoder<Base64.Config>.Feed {

--- a/sample/src/commonMain/kotlin/Main.kt
+++ b/sample/src/commonMain/kotlin/Main.kt
@@ -14,66 +14,27 @@
  * limitations under the License.
  **/
 
-import io.matthewnelson.encoding.builders.*
+import io.matthewnelson.encoding.base16.Base16
+import io.matthewnelson.encoding.base32.Base32
+import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 
 fun main() {
-    val base16EncoderDecoder = Base16 {
-        isLenient = false
-        lineBreakInterval = 64
-        encodeToLowercase = true
-    }
-
-    val base32CrockfordEncoderDecoder = Base32Crockford {
-        isLenient = false
-        encodeToLowercase = false
-        hyphenInterval = 5
-        checkSymbol('*')
-    }
-
-    val base32DefaultEncoderDecoder = Base32Default {
-        isLenient = false
-        lineBreakInterval = 64
-        encodeToLowercase = true
-        padEncoded = false
-    }
-
-    val base32HexEncoderDecoder = Base32Hex {
-        isLenient = false
-        lineBreakInterval = 64
-        encodeToLowercase = true
-        padEncoded = false
-    }
-
-    val base64DefaultEncoderDecoder = Base64 {
-        isLenient = true
-        lineBreakInterval = 64
-        encodeToUrlSafe = false
-        padEncoded = true
-    }
-
-    val base64UrlSafeEncoderDecoder = Base64 {
-        isLenient = false
-        lineBreakInterval = 64
-        encodeToUrlSafe = true
-        padEncoded = false
-    }
-
     val bytes = "Hello World!".encodeToByteArray()
 
-    val base16 = bytes.encodeToString(base16EncoderDecoder)
+    val base16 = bytes.encodeToString(Base16)
 
-    val crockford = bytes.encodeToString(base32CrockfordEncoderDecoder)
-    val default = bytes.encodeToString(base32DefaultEncoderDecoder)
-    val hex = bytes.encodeToString(base32HexEncoderDecoder)
+    val crockford = bytes.encodeToString(Base32.Crockford)
+    val default = bytes.encodeToString(Base32.Default)
+    val hex = bytes.encodeToString(Base32.Hex)
 
-    val base64 = bytes.encodeToString(base64DefaultEncoderDecoder)
-    val base64UrlSafe = bytes.encodeToString(base64UrlSafeEncoderDecoder)
+    val base64 = bytes.encodeToString(Base64.Default)
+    val base64UrlSafe = bytes.encodeToString(Base64.UrlSafe)
 
     println("'Hello World!' Encodes to:")
     println("    Base16 (hex): $base16")
 
-    println("    Base32 Crockford[checkSymbol = *, hyphenInterval = 5]: $crockford")
+    println("    Base32 Crockford[hyphenInterval = 4]: $crockford")
     println("    Base32 Default: $default")
     println("    Base32 Hex: $hex")
 


### PR DESCRIPTION
Closes #121 

Cleans up #117 where by instead of higher level implementations using `INSTANCE`, their `companion object`s now extend `EncoderDecoder` and delegate the overrides to their static references.