### PR TITLE
Move builders to package `...encoding.base*`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,29 @@
+# MIGRATION
+
+## Preamble
+
+`2.0.0` release contained a breaking API change which broke binary compatibility. 
+This was attributed to an issue with Java 9 `Module`s, for which JPMS disallows 
+split packages. The `encoding-base16`, `encoding-base32` and `encoding-base64` 
+dependencies were the cause of the issue because their builder classes and functions 
+were located in the same package named `io.matthewnelson.encoding.builders`. Those 
+classes and functions were subsequently deprecated in release `1.2.3` so consumers 
+could gracefully update before upgrading to `2.0.0` where they have been removed.
+
+For more details, see [[#124]][124].
+
+## Migration guide for 1.x.x -> 2.0.0
+
+ - Update dependency to `1.2.3`
+     - Migration method 1:
+         - Use your IDE or editor to search your project for the following
+           ```
+           import io.matthewnelson.encoding.builders
+           ```
+         - Replace `.builders` with the new package location (either `base16`, `base32`, or `base64`)
+     - Migration method 2:
+         - Use the provided `ReplaceWith` functionality of the `@Deprecated` notice 
+           to update to the new builder class/function package locations.
+ - Update dependency to `2.0.0`
+
+[124]: https://github.com/05nelsonm/encoding/issues/124

--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -21,6 +21,24 @@ public final class io/matthewnelson/encoding/base16/Base16$Config : io/matthewne
 	public synthetic fun <init> (ZBZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class io/matthewnelson/encoding/base16/Base16ConfigBuilder {
+	public field encodeToLowercase Z
+	public field isLenient Z
+	public field lineBreakInterval B
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base16/Base16$Config;
+	public final fun strict ()Lio/matthewnelson/encoding/base16/Base16ConfigBuilder;
+}
+
+public final class io/matthewnelson/encoding/base16/BuildersKt {
+	public static final fun Base16 ()Lio/matthewnelson/encoding/base16/Base16;
+	public static final fun Base16 (Lio/matthewnelson/encoding/base16/Base16$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base16/Base16;
+	public static final fun Base16 (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base16/Base16;
+	public static final fun Base16 (Z)Lio/matthewnelson/encoding/base16/Base16;
+	public static synthetic fun Base16$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base16/Base16;
+}
+
 public final class io/matthewnelson/encoding/builders/Base16ConfigBuilder {
 	public field encodeToLowercase Z
 	public field isLenient Z

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
@@ -17,7 +17,7 @@
 
 package io.matthewnelson.component.encoding.base16
 
-import io.matthewnelson.encoding.builders.Base16
+import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray
@@ -28,7 +28,7 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base16())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.base16.Base16",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
@@ -44,7 +44,7 @@ public inline fun String.decodeBase16ToArray(): ByteArray? {
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base16())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.base16.Base16",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
@@ -59,7 +59,7 @@ public fun CharArray.decodeBase16ToArray(): ByteArray? {
     replaceWith = ReplaceWith(
         expression = "this.encodeToString(Base16())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.base16.Base16",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
         ],
     ),
@@ -75,7 +75,7 @@ public inline fun ByteArray.encodeBase16(): String {
     replaceWith = ReplaceWith(
         expression = "this.encodeToCharArray(Base16())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.base16.Base16",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
         ],
     ),
@@ -91,7 +91,7 @@ public inline fun ByteArray.encodeBase16ToCharArray(): CharArray {
     ReplaceWith(
         expression = "this.encodeToByteArray(Base16())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.base16.Base16",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
         ],
     ),

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -17,8 +17,6 @@
 
 package io.matthewnelson.encoding.base16
 
-import io.matthewnelson.encoding.builders.Base16
-import io.matthewnelson.encoding.builders.Base16ConfigBuilder
 import io.matthewnelson.encoding.core.*
 import io.matthewnelson.encoding.core.util.DecoderInput
 import io.matthewnelson.encoding.core.util.FeedBuffer
@@ -49,7 +47,7 @@ import kotlin.jvm.JvmSynthetic
  *     val decoded = encoded.decodeToByteArray(Base16).decodeToString()
  *     assertEquals(text, decoded)
  *
- * @see [io.matthewnelson.encoding.builders.Base16]
+ * @see [io.matthewnelson.encoding.base16.Base16]
  * @see [Base16.Config]
  * @see [Base16.CHARS_UPPER]
  * @see [Base16.CHARS_LOWER]

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Builders.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Builders.kt
@@ -13,30 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("SpellCheckingInspection", "DEPRECATION")
+@file:Suppress("SpellCheckingInspection")
 
-package io.matthewnelson.encoding.builders
+package io.matthewnelson.encoding.base16
 
 import io.matthewnelson.encoding.base16.Base16.Config
-import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.EncodingException
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmOverloads
 
 /**
- * Deprecated
+ * Creates a configured [Base16] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base16.Base16]
+ * @param [config] inherit settings from.
+ * @see [Base16ConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base16",
-    replaceWith = ReplaceWith(
-        expression = "Base16(config) { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base16.Base16"
-        ]
-    )
-)
 public fun Base16(
     config: Config?,
     block: Base16ConfigBuilder.() -> Unit
@@ -47,19 +38,10 @@ public fun Base16(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base16] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base16.Base16]
+ * @see [Base16ConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base16",
-    replaceWith = ReplaceWith(
-        expression = "Base16 { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base16.Base16"
-        ]
-    )
-)
 public fun Base16(
     block: Base16ConfigBuilder.() -> Unit
 ): Base16 {
@@ -67,37 +49,23 @@ public fun Base16(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base16] encoder/decoder
+ * using the default settings.
  *
- * @see [io.matthewnelson.encoding.base16.Base16]
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with RFC 4648.
+ * @see [Base16ConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base16",
-    replaceWith = ReplaceWith(
-        expression = "Base16(strict)",
-        imports = [
-            "io.matthewnelson.encoding.base16.Base16"
-        ]
-    )
-)
 @JvmOverloads
 public fun Base16(strict: Boolean = false): Base16 = Base16 { if (strict) strict() }
 
 
 /**
- * Deprecated
+ * Builder for creating a [Base16.Config].
  *
- * @see [io.matthewnelson.encoding.base16.Base16ConfigBuilder]
+ * @see [strict]
+ * @see [io.matthewnelson.encoding.base16.Base16]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base16",
-    replaceWith = ReplaceWith(
-        expression = "Base16ConfigBuilder",
-        imports = [
-            "io.matthewnelson.encoding.base16.Base16ConfigBuilder"
-        ]
-    )
-)
 public class Base16ConfigBuilder {
 
     public constructor()
@@ -172,11 +140,5 @@ public class Base16ConfigBuilder {
     /**
      * Builds a [Base16.Config] for the provided settings.
      * */
-    public fun build(): Config {
-        val b = io.matthewnelson.encoding.base16.Base16ConfigBuilder()
-        b.isLenient = isLenient
-        b.lineBreakInterval = lineBreakInterval
-        b.encodeToLowercase = encodeToLowercase
-        return b.build()
-    }
+    public fun build(): Config = Config.from(this)
 }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -29,7 +29,12 @@ import kotlin.jvm.JvmOverloads
  * @see [io.matthewnelson.encoding.base16.Base16]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base16",
+    message = """
+        Moved to package io.matthewnelson.encoding.base16
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base16(config) { block() }",
         imports = [
@@ -52,7 +57,12 @@ public fun Base16(
  * @see [io.matthewnelson.encoding.base16.Base16]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base16",
+    message = """
+        Moved to package io.matthewnelson.encoding.base16
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base16 { block() }",
         imports = [
@@ -72,7 +82,12 @@ public fun Base16(
  * @see [io.matthewnelson.encoding.base16.Base16]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base16",
+    message = """
+        Moved to package io.matthewnelson.encoding.base16
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base16(strict)",
         imports = [
@@ -90,7 +105,12 @@ public fun Base16(strict: Boolean = false): Base16 = Base16 { if (strict) strict
  * @see [io.matthewnelson.encoding.base16.Base16ConfigBuilder]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base16",
+    message = """
+        Moved to package io.matthewnelson.encoding.base16
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base16ConfigBuilder",
         imports = [

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -34,6 +34,8 @@ import kotlin.jvm.JvmOverloads
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base16(config) { block() }",
@@ -62,6 +64,8 @@ public fun Base16(
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base16 { block() }",
@@ -87,6 +91,8 @@ public fun Base16(
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base16(strict)",
@@ -110,6 +116,8 @@ public fun Base16(strict: Boolean = false): Base16 = Base16 { if (strict) strict
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base16ConfigBuilder",

--- a/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
+++ b/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/encoding/base16/Base16UnitTest.kt
@@ -15,7 +15,6 @@
  **/
 package io.matthewnelson.encoding.base16
 
-import io.matthewnelson.encoding.builders.Base16
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -113,6 +113,59 @@ public final class io/matthewnelson/encoding/base32/Base32$Hex$Config : io/matth
 	public synthetic fun <init> (ZBZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class io/matthewnelson/encoding/base32/Base32CrockfordConfigBuilder {
+	public field encodeToLowercase Z
+	public field finalizeWhenFlushed Z
+	public field hyphenInterval B
+	public field isLenient Z
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;
+	public final fun checkSymbol ()Ljava/lang/Character;
+	public final fun checkSymbol (Ljava/lang/Character;)Lio/matthewnelson/encoding/base32/Base32CrockfordConfigBuilder;
+	public final fun strict ()Lio/matthewnelson/encoding/base32/Base32CrockfordConfigBuilder;
+}
+
+public final class io/matthewnelson/encoding/base32/Base32DefaultConfigBuilder {
+	public field encodeToLowercase Z
+	public field isLenient Z
+	public field lineBreakInterval B
+	public field padEncoded Z
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Default$Config;
+	public final fun strict ()Lio/matthewnelson/encoding/base32/Base32DefaultConfigBuilder;
+}
+
+public final class io/matthewnelson/encoding/base32/Base32HexConfigBuilder {
+	public field encodeToLowercase Z
+	public field isLenient Z
+	public field lineBreakInterval B
+	public field padEncoded Z
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Hex$Config;
+	public final fun strict ()Lio/matthewnelson/encoding/base32/Base32HexConfigBuilder;
+}
+
+public final class io/matthewnelson/encoding/base32/BuildersKt {
+	public static final fun Base32Crockford ()Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static final fun Base32Crockford (Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static final fun Base32Crockford (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static final fun Base32Crockford (Z)Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static synthetic fun Base32Crockford$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static final fun Base32Default ()Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static final fun Base32Default (Lio/matthewnelson/encoding/base32/Base32$Default$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static final fun Base32Default (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static final fun Base32Default (Z)Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static synthetic fun Base32Default$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static final fun Base32Hex ()Lio/matthewnelson/encoding/base32/Base32$Hex;
+	public static final fun Base32Hex (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Hex;
+	public static final fun Base32Hex (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Hex;
+	public static final fun Base32Hex (Z)Lio/matthewnelson/encoding/base32/Base32$Hex;
+	public static synthetic fun Base32Hex$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base32/Base32$Hex;
+}
+
 public final class io/matthewnelson/encoding/builders/Base32CrockfordConfigBuilder {
 	public field encodeToLowercase Z
 	public field finalizeWhenFlushed Z

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
@@ -26,9 +26,9 @@
 
 package io.matthewnelson.component.encoding.base32
 
-import io.matthewnelson.encoding.builders.Base32Crockford
-import io.matthewnelson.encoding.builders.Base32Default
-import io.matthewnelson.encoding.builders.Base32Hex
+import io.matthewnelson.encoding.base32.Base32Crockford
+import io.matthewnelson.encoding.base32.Base32Default
+import io.matthewnelson.encoding.base32.Base32Hex
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray
@@ -59,7 +59,7 @@ public sealed class Base32 {
     )
     public data class Crockford @JvmOverloads constructor(
         @Deprecated(
-            message = "Replaced by EncoderDecoder. Use io.matthewnelson.builders.Base32Crockford to set",
+            message = "Replaced by EncoderDecoder. Use io.matthewnelson.base32.Base32Crockford to set",
             level = DeprecationLevel.WARNING
         )
         val checkSymbol: Char? = null
@@ -93,13 +93,13 @@ public sealed class Base32 {
         }
 
         @Deprecated(
-            message = "Replaced by EncoderDecoder. Use io.matthewnelson.builders.Base32Crockford to set",
+            message = "Replaced by EncoderDecoder. Use io.matthewnelson.base32.Base32Crockford to set",
             level = DeprecationLevel.WARNING
         )
         inline val hasCheckSymbol: Boolean get() = checkSymbol != null
 
         @Deprecated(
-            message = "Replaced by EncoderDecoder. Use io.matthewnelson.builders.Base32Crockford to set",
+            message = "Replaced by EncoderDecoder. Use io.matthewnelson.base32.Base32Crockford to set",
             level = DeprecationLevel.WARNING
         )
         inline val checkByte: Byte? get() = checkSymbol?.uppercaseChar()?.code?.toByte()
@@ -161,7 +161,7 @@ public sealed class Base32 {
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base32Default())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.base32.Base32Default",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
@@ -178,7 +178,7 @@ public inline fun String.decodeBase32ToArray(base32: Base32.Default = Base32.Def
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base32Hex())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.base32.Base32Hex",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
@@ -194,7 +194,7 @@ public inline fun String.decodeBase32ToArray(base32: Base32.Hex): ByteArray? {
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base32Crockford { checkSymbol('value') })",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.base32.Base32Crockford",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
@@ -210,7 +210,7 @@ public inline fun String.decodeBase32ToArray(base32: Base32.Crockford): ByteArra
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base32Default())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.base32.Base32Default",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
@@ -226,7 +226,7 @@ public fun CharArray.decodeBase32ToArray(base32: Base32.Default = Base32.Default
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base32Hex())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.base32.Base32Hex",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
@@ -241,7 +241,7 @@ public fun CharArray.decodeBase32ToArray(base32: Base32.Hex): ByteArray? {
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base32Crockford { checkSymbol('value') })",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.base32.Base32Crockford",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
@@ -256,7 +256,7 @@ public fun CharArray.decodeBase32ToArray(base32: Base32.Crockford): ByteArray? {
     replaceWith = ReplaceWith(
         expression = "this.encodeToString(Base32Default())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.base32.Base32Default",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
         ],
     ),
@@ -273,7 +273,7 @@ public inline fun ByteArray.encodeBase32(base32: Base32.Default = Base32.Default
     replaceWith = ReplaceWith(
         expression = "this.encodeToString(Base32Hex())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.base32.Base32Hex",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
         ],
     ),
@@ -289,7 +289,7 @@ public inline fun ByteArray.encodeBase32(base32: Base32.Hex): String {
     replaceWith = ReplaceWith(
         expression = "this.encodeToString(Base32Crockford { checkSymbol('value') })",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.base32.Base32Crockford",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
         ],
     ),
@@ -305,7 +305,7 @@ public inline fun ByteArray.encodeBase32(base32: Base32.Crockford): String {
     replaceWith = ReplaceWith(
         expression = "this.encodeToCharArray(Base32Default())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.base32.Base32Default",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
         ],
     ),
@@ -322,7 +322,7 @@ public inline fun ByteArray.encodeBase32ToCharArray(base32: Base32.Default = Bas
     replaceWith = ReplaceWith(
         expression = "this.encodeToCharArray(Base32Hex())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.base32.Base32Hex",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
         ],
     ),
@@ -338,7 +338,7 @@ public inline fun ByteArray.encodeBase32ToCharArray(base32: Base32.Hex): CharArr
     replaceWith = ReplaceWith(
         expression = "this.encodeToCharArray(Base32Crockford { checkSymbol('value') })",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.base32.Base32Crockford",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
         ],
     ),
@@ -354,7 +354,7 @@ public inline fun ByteArray.encodeBase32ToCharArray(base32: Base32.Crockford): C
     replaceWith = ReplaceWith(
         expression = "this.encodeToByteArray(Base32Default())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.base32.Base32Default",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
         ],
     ),
@@ -370,7 +370,7 @@ public fun ByteArray.encodeBase32ToByteArray(base32: Base32.Default = Base32.Def
     replaceWith = ReplaceWith(
         expression = "this.encodeToByteArray(Base32Hex())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.base32.Base32Hex",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
         ],
     ),
@@ -385,7 +385,7 @@ public fun ByteArray.encodeBase32ToByteArray(base32: Base32.Hex): ByteArray {
     replaceWith = ReplaceWith(
         expression = "this.encodeToByteArray(Base32Crockford { checkSymbol('value') })",
         imports = [
-            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.base32.Base32Crockford",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
         ],
     ),

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -21,7 +21,6 @@ import io.matthewnelson.encoding.base32.internal.decodeOutMaxSize
 import io.matthewnelson.encoding.base32.internal.encodeOutSize
 import io.matthewnelson.encoding.base32.internal.isCheckSymbol
 import io.matthewnelson.encoding.base32.internal.toBits
-import io.matthewnelson.encoding.builders.*
 import io.matthewnelson.encoding.core.*
 import io.matthewnelson.encoding.core.util.*
 import io.matthewnelson.encoding.core.util.FeedBuffer

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Builders.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Builders.kt
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("FunctionName", "SpellCheckingInspection", "DEPRECATION")
+@file:Suppress("FunctionName", "SpellCheckingInspection")
 
-package io.matthewnelson.encoding.builders
+package io.matthewnelson.encoding.base32
 
-import io.matthewnelson.encoding.base32.Base32
 import io.matthewnelson.encoding.base32.internal.isCheckSymbol
 import io.matthewnelson.encoding.core.EncodingException
 import io.matthewnelson.encoding.core.Encoder
@@ -26,19 +25,11 @@ import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
 
 /**
- * Deprecated
+ * Creates a configured [Base32.Crockford] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base32.Base32Crockford]
+ * @param [config] inherit settings from.
+ * @see [Base32CrockfordConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32Crockford(config) { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32Crockford"
-        ]
-    )
-)
 public fun Base32Crockford(
     config: Base32.Crockford.Config?,
     block: Base32CrockfordConfigBuilder.() -> Unit,
@@ -49,19 +40,10 @@ public fun Base32Crockford(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base32.Crockford] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base32.Base32Crockford]
+ * @see [Base32CrockfordConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32Crockford { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32Crockford"
-        ]
-    )
-)
 public fun Base32Crockford(
     block: Base32CrockfordConfigBuilder.() -> Unit,
 ): Base32.Crockford {
@@ -69,36 +51,22 @@ public fun Base32Crockford(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base32.Crockford] encoder/decoder
+ * using the default settings.
  *
- * @see [io.matthewnelson.encoding.base32.Base32Crockford]
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with the Crockford spec.
+ * @see [Base32CrockfordConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32Crockford(strict)",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32Crockford"
-        ]
-    )
-)
 @JvmOverloads
 public fun Base32Crockford(strict: Boolean = false): Base32.Crockford = Base32Crockford { if (strict) strict() }
 
 /**
- * Deprecated
+ * Creates a configured [Base32.Default] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base32.Base32Default]
+ * @param [config] to inherit from.
+ * @see [Base32DefaultConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32Default(config) { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32Default"
-        ]
-    )
-)
 public fun Base32Default(
     config: Base32.Default.Config?,
     block: Base32DefaultConfigBuilder.() -> Unit,
@@ -109,19 +77,10 @@ public fun Base32Default(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base32.Default] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base32.Base32Default]
+ * @see [Base32DefaultConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32Default { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32Default"
-        ]
-    )
-)
 public fun Base32Default(
     block: Base32DefaultConfigBuilder.() -> Unit,
 ): Base32.Default {
@@ -129,36 +88,22 @@ public fun Base32Default(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base32.Default] encoder/decoder
+ * using the default settings.
  *
- * @see [io.matthewnelson.encoding.base32.Base32Default]
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with RFC 4648.
+ * @see [Base32DefaultConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32Default(strict)",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32Default"
-        ]
-    )
-)
 @JvmOverloads
 public fun Base32Default(strict: Boolean = false): Base32.Default = Base32Default { if (strict) strict() }
 
 /**
- * Deprecated
+ * Creates a configured [Base32.Hex] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base32.Base32Hex]
+ * @param [config] to inherit from.
+ * @see [Base32HexConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32Hex(config) { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32Hex"
-        ]
-    )
-)
 public fun Base32Hex(
     config: Base32.Hex.Config?,
     block: Base32HexConfigBuilder.() -> Unit,
@@ -169,19 +114,10 @@ public fun Base32Hex(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base32.Hex] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base32.Base32Hex]
+ * @see [Base32HexConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32Hex { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32Hex"
-        ]
-    )
-)
 public fun Base32Hex(
     block: Base32HexConfigBuilder.() -> Unit,
 ): Base32.Hex {
@@ -189,36 +125,22 @@ public fun Base32Hex(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base32.Hex] encoder/decoder
+ * using the default settings.
  *
- * @see [io.matthewnelson.encoding.base32.Base32Hex]
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with RFC 4648.
+ * @see [Base32HexConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32Hex(strict)",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32Hex"
-        ]
-    )
-)
 @JvmOverloads
 public fun Base32Hex(strict: Boolean = false): Base32.Hex = Base32Hex { if (strict) strict() }
 
 /**
- * Deprecated
+ * Builder for creating a [Base32.Crockford.Config].
  *
- * @see [io.matthewnelson.encoding.base32.Base32CrockfordConfigBuilder]
+ * @see [strict]
+ * @see [Base32Crockford]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32CrockfordConfigBuilder",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32CrockfordConfigBuilder"
-        ]
-    )
-)
 public class Base32CrockfordConfigBuilder {
 
     public constructor()
@@ -374,31 +296,15 @@ public class Base32CrockfordConfigBuilder {
     /**
      * Builds a [Base32.Crockford.Config] for the provided settings.
      * */
-    public fun build(): Base32.Crockford.Config {
-        val b = io.matthewnelson.encoding.base32.Base32CrockfordConfigBuilder()
-        b.isLenient = isLenient
-        b.encodeToLowercase = encodeToLowercase
-        b.hyphenInterval = hyphenInterval
-        b.checkSymbol(checkSymbol)
-        b.finalizeWhenFlushed = finalizeWhenFlushed
-        return b.build()
-    }
+    public fun build(): Base32.Crockford.Config = Base32.Crockford.Config.from(this)
 }
 
 /**
- * Deprecated
+ * Builder for creating a [Base32.Default.Config].
  *
- * @see [io.matthewnelson.encoding.base32.Base32DefaultConfigBuilder]
+ * @see [strict]
+ * @see [Base32Default]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32DefaultConfigBuilder",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32DefaultConfigBuilder"
-        ]
-    )
-)
 public class Base32DefaultConfigBuilder {
 
     public constructor()
@@ -485,30 +391,15 @@ public class Base32DefaultConfigBuilder {
     /**
      * Builds a [Base32.Default.Config] for the provided settings.
      * */
-    public fun build(): Base32.Default.Config {
-        val b = io.matthewnelson.encoding.base32.Base32DefaultConfigBuilder()
-        b.isLenient = isLenient
-        b.lineBreakInterval = lineBreakInterval
-        b.encodeToLowercase = encodeToLowercase
-        b.padEncoded = padEncoded
-        return b.build()
-    }
+    public fun build(): Base32.Default.Config = Base32.Default.Config.from(this)
 }
 
 /**
- * Deprecated
+ * Builder for creating a [Base32.Hex.Config].
  *
- * @see [io.matthewnelson.encoding.base32.Base32HexConfigBuilder]
+ * @see [strict]
+ * @see [Base32Hex]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
-    replaceWith = ReplaceWith(
-        expression = "Base32HexConfigBuilder",
-        imports = [
-            "io.matthewnelson.encoding.base32.Base32HexConfigBuilder"
-        ]
-    )
-)
 public class Base32HexConfigBuilder {
 
     public constructor()
@@ -595,12 +486,5 @@ public class Base32HexConfigBuilder {
     /**
      * Builds a [Base32.Hex.Config] for the provided settings.
      * */
-    public fun build(): Base32.Hex.Config {
-        val b = io.matthewnelson.encoding.base32.Base32HexConfigBuilder()
-        b.isLenient = isLenient
-        b.lineBreakInterval = lineBreakInterval
-        b.encodeToLowercase = encodeToLowercase
-        b.padEncoded = padEncoded
-        return b.build()
-    }
+    public fun build(): Base32.Hex.Config = Base32.Hex.Config.from(this)
 }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -31,7 +31,13 @@ import kotlin.jvm.JvmOverloads
  * @see [io.matthewnelson.encoding.base32.Base32Crockford]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+    
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """
+    ,
     replaceWith = ReplaceWith(
         expression = "Base32Crockford(config) { block() }",
         imports = [
@@ -54,7 +60,12 @@ public fun Base32Crockford(
  * @see [io.matthewnelson.encoding.base32.Base32Crockford]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+    Moved to package io.matthewnelson.encoding.base32
+    
+    Will be removed in 2.0.0 because of an issue with
+    Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32Crockford { block() }",
         imports = [
@@ -74,7 +85,12 @@ public fun Base32Crockford(
  * @see [io.matthewnelson.encoding.base32.Base32Crockford]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32Crockford(strict)",
         imports = [
@@ -91,7 +107,12 @@ public fun Base32Crockford(strict: Boolean = false): Base32.Crockford = Base32Cr
  * @see [io.matthewnelson.encoding.base32.Base32Default]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32Default(config) { block() }",
         imports = [
@@ -114,7 +135,12 @@ public fun Base32Default(
  * @see [io.matthewnelson.encoding.base32.Base32Default]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32Default { block() }",
         imports = [
@@ -134,7 +160,12 @@ public fun Base32Default(
  * @see [io.matthewnelson.encoding.base32.Base32Default]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32Default(strict)",
         imports = [
@@ -151,7 +182,12 @@ public fun Base32Default(strict: Boolean = false): Base32.Default = Base32Defaul
  * @see [io.matthewnelson.encoding.base32.Base32Hex]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32Hex(config) { block() }",
         imports = [
@@ -174,7 +210,12 @@ public fun Base32Hex(
  * @see [io.matthewnelson.encoding.base32.Base32Hex]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32Hex { block() }",
         imports = [
@@ -194,7 +235,12 @@ public fun Base32Hex(
  * @see [io.matthewnelson.encoding.base32.Base32Hex]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32Hex(strict)",
         imports = [
@@ -211,7 +257,12 @@ public fun Base32Hex(strict: Boolean = false): Base32.Hex = Base32Hex { if (stri
  * @see [io.matthewnelson.encoding.base32.Base32CrockfordConfigBuilder]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32CrockfordConfigBuilder",
         imports = [
@@ -391,7 +442,12 @@ public class Base32CrockfordConfigBuilder {
  * @see [io.matthewnelson.encoding.base32.Base32DefaultConfigBuilder]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32DefaultConfigBuilder",
         imports = [
@@ -501,7 +557,12 @@ public class Base32DefaultConfigBuilder {
  * @see [io.matthewnelson.encoding.base32.Base32HexConfigBuilder]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base32",
+    message = """
+        Moved to package io.matthewnelson.encoding.base32
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base32HexConfigBuilder",
         imports = [

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -36,6 +36,8 @@ import kotlin.jvm.JvmOverloads
     
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """
     ,
     replaceWith = ReplaceWith(
@@ -65,6 +67,8 @@ public fun Base32Crockford(
     
     Will be removed in 2.0.0 because of an issue with
     Java 9 modules and JPMS not allowing split packages
+    
+    See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32Crockford { block() }",
@@ -90,6 +94,8 @@ public fun Base32Crockford(
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32Crockford(strict)",
@@ -112,6 +118,8 @@ public fun Base32Crockford(strict: Boolean = false): Base32.Crockford = Base32Cr
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32Default(config) { block() }",
@@ -140,6 +148,8 @@ public fun Base32Default(
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32Default { block() }",
@@ -165,6 +175,8 @@ public fun Base32Default(
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32Default(strict)",
@@ -187,6 +199,8 @@ public fun Base32Default(strict: Boolean = false): Base32.Default = Base32Defaul
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32Hex(config) { block() }",
@@ -215,6 +229,8 @@ public fun Base32Hex(
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32Hex { block() }",
@@ -240,6 +256,8 @@ public fun Base32Hex(
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32Hex(strict)",
@@ -262,6 +280,8 @@ public fun Base32Hex(strict: Boolean = false): Base32.Hex = Base32Hex { if (stri
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32CrockfordConfigBuilder",
@@ -447,6 +467,8 @@ public class Base32CrockfordConfigBuilder {
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32DefaultConfigBuilder",
@@ -562,6 +584,8 @@ public class Base32DefaultConfigBuilder {
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base32HexConfigBuilder",

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32CrockfordUnitTest.kt
@@ -17,7 +17,6 @@
 
 package io.matthewnelson.encoding.base32
 
-import io.matthewnelson.encoding.builders.Base32Crockford
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
@@ -17,7 +17,6 @@
 
 package io.matthewnelson.encoding.base32
 
-import io.matthewnelson.encoding.builders.Base32Default
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32HexUnitTest.kt
@@ -17,7 +17,6 @@
 
 package io.matthewnelson.encoding.base32
 
-import io.matthewnelson.encoding.builders.Base32Hex
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString

--- a/library/encoding-base64/api/encoding-base64.api
+++ b/library/encoding-base64/api/encoding-base64.api
@@ -61,6 +61,25 @@ public final class io/matthewnelson/encoding/base64/Base64$UrlSafe : io/matthewn
 	public static final field INSTANCE Lio/matthewnelson/encoding/base64/Base64$UrlSafe;
 }
 
+public final class io/matthewnelson/encoding/base64/Base64ConfigBuilder {
+	public field encodeToUrlSafe Z
+	public field isLenient Z
+	public field lineBreakInterval B
+	public field padEncoded Z
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base64/Base64$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base64/Base64$Config;
+	public final fun strict ()Lio/matthewnelson/encoding/base64/Base64ConfigBuilder;
+}
+
+public final class io/matthewnelson/encoding/base64/BuildersKt {
+	public static final fun Base64 ()Lio/matthewnelson/encoding/base64/Base64;
+	public static final fun Base64 (Lio/matthewnelson/encoding/base64/Base64$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base64/Base64;
+	public static final fun Base64 (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base64/Base64;
+	public static final fun Base64 (Z)Lio/matthewnelson/encoding/base64/Base64;
+	public static synthetic fun Base64$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base64/Base64;
+}
+
 public final class io/matthewnelson/encoding/builders/Base64BuildersKt {
 	public static final fun Base64 ()Lio/matthewnelson/encoding/base64/Base64;
 	public static final fun Base64 (Lio/matthewnelson/encoding/base64/Base64$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base64/Base64;

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
@@ -34,7 +34,6 @@
 
 package io.matthewnelson.component.base64
 
-import io.matthewnelson.encoding.builders.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray
@@ -118,7 +117,7 @@ public sealed class Base64 {
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base64())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.base64.Base64",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
@@ -126,7 +125,7 @@ public sealed class Base64 {
 )
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase64ToArray(): ByteArray? {
-    return decodeToByteArrayOrNull(Base64())
+    return decodeToByteArrayOrNull(io.matthewnelson.encoding.base64.Base64())
 }
 
 @Deprecated(
@@ -134,14 +133,14 @@ public inline fun String.decodeBase64ToArray(): ByteArray? {
     replaceWith = ReplaceWith(
         expression = "this.decodeToByteArrayOrNull(Base64())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.base64.Base64",
             "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
         ],
     ),
     level = DeprecationLevel.WARNING,
 )
 public fun CharArray.decodeBase64ToArray(): ByteArray? {
-    return decodeToByteArrayOrNull(Base64())
+    return decodeToByteArrayOrNull(io.matthewnelson.encoding.base64.Base64())
 }
 
 @Deprecated(
@@ -149,7 +148,7 @@ public fun CharArray.decodeBase64ToArray(): ByteArray? {
     replaceWith = ReplaceWith(
         expression = "this.encodeToString(Base64())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.base64.Base64",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
         ],
     ),
@@ -158,7 +157,7 @@ public fun CharArray.decodeBase64ToArray(): ByteArray? {
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase64(base64: Base64.Default = Base64.Default): String {
-    return encodeToString(Base64())
+    return encodeToString(io.matthewnelson.encoding.base64.Base64())
 }
 
 @Deprecated(
@@ -166,7 +165,7 @@ public inline fun ByteArray.encodeBase64(base64: Base64.Default = Base64.Default
     replaceWith = ReplaceWith(
         expression = "this.encodeToString(Base64 { encodeToUrlSafe = true; padEncoded = true/false })",
         imports = [
-            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.base64.Base64",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
         ],
     ),
@@ -174,7 +173,7 @@ public inline fun ByteArray.encodeBase64(base64: Base64.Default = Base64.Default
 )
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase64(base64: Base64.UrlSafe): String {
-    return encodeToString(Base64 {
+    return encodeToString(io.matthewnelson.encoding.base64.Base64 {
         encodeToUrlSafe = true
         padEncoded = base64.pad
     })
@@ -185,7 +184,7 @@ public inline fun ByteArray.encodeBase64(base64: Base64.UrlSafe): String {
     replaceWith = ReplaceWith(
         expression = "this.encodeToCharArray(Base64())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.base64.Base64",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
         ],
     ),
@@ -194,7 +193,7 @@ public inline fun ByteArray.encodeBase64(base64: Base64.UrlSafe): String {
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.Default = Base64.Default): CharArray {
-    return encodeToCharArray(Base64())
+    return encodeToCharArray(io.matthewnelson.encoding.base64.Base64())
 }
 
 @Deprecated(
@@ -202,7 +201,7 @@ public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.Default = Bas
     replaceWith = ReplaceWith(
         expression = "this.encodeToCharArray(Base64 { encodeToUrlSafe = true; padEncoded = true/false })",
         imports = [
-            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.base64.Base64",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
         ],
     ),
@@ -210,7 +209,7 @@ public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.Default = Bas
 )
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.UrlSafe): CharArray {
-    return encodeToCharArray(Base64 {
+    return encodeToCharArray(io.matthewnelson.encoding.base64.Base64 {
         encodeToUrlSafe = true
         padEncoded = base64.pad
     })
@@ -221,7 +220,7 @@ public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.UrlSafe): Cha
     replaceWith = ReplaceWith(
         expression = "this.encodeToByteArray(Base64())",
         imports = [
-            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.base64.Base64",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
         ],
     ),
@@ -229,7 +228,7 @@ public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.UrlSafe): Cha
 )
 @JvmOverloads
 public fun ByteArray.encodeBase64ToByteArray(base64: Base64.Default = Base64.Default): ByteArray {
-    return encodeToByteArray(Base64())
+    return encodeToByteArray(io.matthewnelson.encoding.base64.Base64())
 }
 
 @Deprecated(
@@ -237,14 +236,14 @@ public fun ByteArray.encodeBase64ToByteArray(base64: Base64.Default = Base64.Def
     replaceWith = ReplaceWith(
         expression = "this.encodeToByteArray(Base64 { encodeToUrlSafe = true; padEncoded = true/false })",
         imports = [
-            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.base64.Base64",
             "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
         ],
     ),
     level = DeprecationLevel.WARNING,
 )
 public fun ByteArray.encodeBase64ToByteArray(base64: Base64.UrlSafe): ByteArray {
-    return encodeToByteArray(Base64 {
+    return encodeToByteArray(io.matthewnelson.encoding.base64.Base64 {
         encodeToUrlSafe = true
         padEncoded = base64.pad
     })

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -17,9 +17,6 @@
 
 package io.matthewnelson.encoding.base64
 
-import io.matthewnelson.encoding.base64.Base64.Default
-import io.matthewnelson.encoding.builders.Base64
-import io.matthewnelson.encoding.builders.Base64ConfigBuilder
 import io.matthewnelson.encoding.core.*
 import io.matthewnelson.encoding.core.util.DecoderInput
 import io.matthewnelson.encoding.core.util.FeedBuffer
@@ -55,7 +52,7 @@ import kotlin.jvm.JvmSynthetic
  *     val decoded = encoded.decodeToByteArray(Base64.Default).decodeToString()
  *     assertEquals(text, decoded)
  *
- * @see [io.matthewnelson.encoding.builders.Base64]
+ * @see [io.matthewnelson.encoding.base64.Base64]
  * @see [Base64.Config]
  * @see [Default.CHARS]
  * @see [UrlSafe.CHARS]

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Builders.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Builders.kt
@@ -13,29 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("DEPRECATION")
+package io.matthewnelson.encoding.base64
 
-package io.matthewnelson.encoding.builders
-
-import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.EncodingException
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmOverloads
 
 /**
- * Deprecated
+ * Creates a configured [Base64] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base64.Base64]
+ * @param [config] inherit settings from.
+ * @see [Base64ConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base64",
-    replaceWith = ReplaceWith(
-        expression = "Base64(config) { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base64.Base64"
-        ]
-    )
-)
 public fun Base64(
     config: Base64.Config?,
     block: Base64ConfigBuilder.() -> Unit,
@@ -46,19 +35,10 @@ public fun Base64(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base64] encoder/decoder.
  *
- * @see [io.matthewnelson.encoding.base64.Base64]
+ * @see [Base64ConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base64",
-    replaceWith = ReplaceWith(
-        expression = "Base64 { block() }",
-        imports = [
-            "io.matthewnelson.encoding.base64.Base64"
-        ]
-    )
-)
 public fun Base64(
     block: Base64ConfigBuilder.() -> Unit,
 ): Base64 {
@@ -66,36 +46,22 @@ public fun Base64(
 }
 
 /**
- * Deprecated
+ * Creates a configured [Base64] encoder/decoder
+ * using the default settings.
  *
- * @see [io.matthewnelson.encoding.base64.Base64]
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with RFC 4648.
+ * @see [Base64ConfigBuilder]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base64",
-    replaceWith = ReplaceWith(
-        expression = "Base64(strict)",
-        imports = [
-            "io.matthewnelson.encoding.base64.Base64"
-        ]
-    )
-)
 @JvmOverloads
 public fun Base64(strict: Boolean = false): Base64 = Base64 { if (strict) strict() }
 
 /**
- * Deprecated
+ * Builder for creating a [Base64.Config].
  *
- * @see [io.matthewnelson.encoding.base64.Base64ConfigBuilder]
+ * @see [strict]
+ * @see [io.matthewnelson.encoding.builders.Base64]
  * */
-@Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base64",
-    replaceWith = ReplaceWith(
-        expression = "Base64ConfigBuilder",
-        imports = [
-            "io.matthewnelson.encoding.base64.Base64ConfigBuilder"
-        ]
-    )
-)
 public class Base64ConfigBuilder {
 
     public constructor()
@@ -177,12 +143,5 @@ public class Base64ConfigBuilder {
         return this
     }
 
-    public fun build(): Base64.Config {
-        val b = io.matthewnelson.encoding.base64.Base64ConfigBuilder()
-        b.isLenient = isLenient
-        b.lineBreakInterval = lineBreakInterval
-        b.encodeToUrlSafe = encodeToUrlSafe
-        b.padEncoded = padEncoded
-        return b.build()
-    }
+    public fun build(): Base64.Config = Base64.Config.from(this)
 }

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
@@ -28,7 +28,12 @@ import kotlin.jvm.JvmOverloads
  * @see [io.matthewnelson.encoding.base64.Base64]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base64",
+    message = """
+        Moved to package io.matthewnelson.encoding.base64
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base64(config) { block() }",
         imports = [
@@ -51,7 +56,12 @@ public fun Base64(
  * @see [io.matthewnelson.encoding.base64.Base64]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base64",
+    message = """
+        Moved to package io.matthewnelson.encoding.base64
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base64 { block() }",
         imports = [
@@ -71,7 +81,12 @@ public fun Base64(
  * @see [io.matthewnelson.encoding.base64.Base64]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base64",
+    message = """
+        Moved to package io.matthewnelson.encoding.base64
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base64(strict)",
         imports = [
@@ -88,7 +103,12 @@ public fun Base64(strict: Boolean = false): Base64 = Base64 { if (strict) strict
  * @see [io.matthewnelson.encoding.base64.Base64ConfigBuilder]
  * */
 @Deprecated(
-    message = "Moved to package io.matthewnelson.encoding.base64",
+    message = """
+        Moved to package io.matthewnelson.encoding.base64
+        
+        Will be removed in 2.0.0 because of an issue with
+        Java 9 modules and JPMS not allowing split packages
+    """,
     replaceWith = ReplaceWith(
         expression = "Base64ConfigBuilder",
         imports = [

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
@@ -33,6 +33,8 @@ import kotlin.jvm.JvmOverloads
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base64(config) { block() }",
@@ -61,6 +63,8 @@ public fun Base64(
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base64 { block() }",
@@ -86,6 +90,8 @@ public fun Base64(
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base64(strict)",
@@ -108,6 +114,8 @@ public fun Base64(strict: Boolean = false): Base64 = Base64 { if (strict) strict
         
         Will be removed in 2.0.0 because of an issue with
         Java 9 modules and JPMS not allowing split packages
+        
+        See: https://github.com/05nelsonm/encoding/blob/master/MIGRATION.md
     """,
     replaceWith = ReplaceWith(
         expression = "Base64ConfigBuilder",

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64DefaultUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64DefaultUnitTest.kt
@@ -17,7 +17,6 @@
 
 package io.matthewnelson.encoding.base64
 
-import io.matthewnelson.encoding.builders.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64UrlSafeUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/encoding/base64/Base64UrlSafeUnitTest.kt
@@ -18,7 +18,6 @@
 package io.matthewnelson.encoding.base64
 
 import io.matthewnelson.encoding.test.BaseNEncodingTest
-import io.matthewnelson.encoding.builders.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString


### PR DESCRIPTION
Refer to #124 

Note: This PR needs to be tested yet to see if the [proposed deprecation cycle](https://github.com/05nelsonm/encoding/issues/124#issuecomment-1598812238) will work. Will publish a `-SNAPSHOT` to see if new module exports would work. Otherwise, `...encoding.builders` packages must be deleted entirely and a major version release needs to be published.

Adding the `blocked` label to prohibit merging until the aforementioned testing of the `-SNAPSHOT` is completed.