### PR TITLE
Ensure local `StringBuilder` for `encodeToString` is cleared before returning output

### DIFF
--- a/library/base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -102,7 +102,7 @@ public class Base16(config: Base16.Config): EncoderDecoder<Base16.Config>(config
         }
 
         protected override fun toStringAddSettings(): Set<Setting> {
-            return buildSet {
+            return LinkedHashSet<Setting>(3, 1.0f).apply {
                 add(Setting(name = "encodeToLowercase", value = encodeToLowercase))
                 add(Setting(name = "isConstantTime", value = isConstantTime))
             }

--- a/library/base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -172,7 +172,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             }
 
             protected override fun toStringAddSettings(): Set<Setting> {
-                return buildSet {
+                return LinkedHashSet<Setting>(6, 1.0f).apply {
                     add(Setting(name = "encodeToLowercase", value = encodeToLowercase))
                     add(Setting(name = "hyphenInterval", value = hyphenInterval))
                     add(Setting(name = "checkSymbol", value = checkSymbol))
@@ -554,7 +554,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             }
 
             protected override fun toStringAddSettings(): Set<Setting> {
-                return buildSet {
+                return LinkedHashSet<Setting>(4, 1.0f).apply {
                     add(Setting(name = "encodeToLowercase", value = encodeToLowercase))
                     add(Setting(name = "padEncoded", value = padEncoded))
                     add(Setting(name = "isConstantTime", value = isConstantTime))
@@ -783,7 +783,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             }
 
             protected override fun toStringAddSettings(): Set<Setting> {
-                return buildSet {
+                return LinkedHashSet<Setting>(4, 1.0f).apply {
                     add(Setting(name = "encodeToLowercase", value = encodeToLowercase))
                     add(Setting(name = "padEncoded", value = padEncoded))
                     add(Setting(name = "isConstantTime", value = isConstantTime))

--- a/library/base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -114,7 +114,7 @@ public class Base64(config: Base64.Config): EncoderDecoder<Base64.Config>(config
         }
 
         protected override fun toStringAddSettings(): Set<Setting> {
-            return buildSet {
+            return LinkedHashSet<Setting>(4, 1.0f).apply {
                 add(Setting(name = "encodeToUrlSafe", value = encodeToUrlSafe))
                 add(Setting(name = "padEncoded", value = padEncoded))
                 add(Setting(name = "isConstantTime", value = isConstantTime))

--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -180,9 +180,7 @@ public sealed class Decoder<C: EncoderDecoder.Config>(public val config: C) {
         @Throws(EncodingException::class)
         public fun CharSequence.decodeToByteArray(decoder: Decoder<*>): ByteArray {
             return decoder.decode(DecoderInput(this)) { feed ->
-                forEach { c ->
-                    feed.consume(c)
-                }
+                forEach { c -> feed.consume(c) }
             }
         }
 
@@ -206,9 +204,7 @@ public sealed class Decoder<C: EncoderDecoder.Config>(public val config: C) {
         @Throws(EncodingException::class)
         public fun CharArray.decodeToByteArray(decoder: Decoder<*>): ByteArray {
             return decoder.decode(DecoderInput(this)) { feed ->
-                forEach { c ->
-                    feed.consume(c)
-                }
+                forEach { c -> feed.consume(c) }
             }
         }
 
@@ -232,9 +228,7 @@ public sealed class Decoder<C: EncoderDecoder.Config>(public val config: C) {
         @Throws(EncodingException::class)
         public fun ByteArray.decodeToByteArray(decoder: Decoder<*>): ByteArray {
             return decoder.decode(DecoderInput(this)) { feed ->
-                forEach { b ->
-                    feed.consume(b.toInt().toChar())
-                }
+                forEach { b -> feed.consume(b.toInt().toChar()) }
             }
         }
 

--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
@@ -158,12 +158,12 @@ public sealed class Encoder<C: EncoderDecoder.Config>(config: C): Decoder<C>(con
         public fun ByteArray.encodeToString(encoder: Encoder<*>): String {
             return encoder.encodeOutSizeOrFail(size) { outSize ->
                 val sb = StringBuilder(outSize)
-
-                encoder.encode(this) { char ->
-                    sb.append(char)
-                }
-
-                sb.toString()
+                encoder.encode(this) { c -> sb.append(c) }
+                val count = sb.count()
+                val out = sb.toString()
+                sb.clear()
+                repeat(count) { sb.append(' ') }
+                out
             }
         }
 
@@ -182,14 +182,10 @@ public sealed class Encoder<C: EncoderDecoder.Config>(config: C): Decoder<C>(con
         @Throws(EncodingSizeException::class)
         public fun ByteArray.encodeToCharArray(encoder: Encoder<*>): CharArray {
             return encoder.encodeOutSizeOrFail(size) { outSize ->
-                val ca = CharArray(outSize)
-
                 var i = 0
-                encoder.encode(this) { char ->
-                    ca[i++] = char
-                }
-
-                ca
+                val a = CharArray(outSize)
+                encoder.encode(this) { c -> a[i++] = c }
+                a
             }
         }
 
@@ -208,14 +204,10 @@ public sealed class Encoder<C: EncoderDecoder.Config>(config: C): Decoder<C>(con
         @Throws(EncodingSizeException::class)
         public fun ByteArray.encodeToByteArray(encoder: Encoder<*>): ByteArray {
             return encoder.encodeOutSizeOrFail(size) { outSize ->
-                val ba = ByteArray(outSize)
-
                 var i = 0
-                encoder.encode(this) { char ->
-                    ba[i++] = char.code.toByte()
-                }
-
-                ba
+                val a = ByteArray(outSize)
+                encoder.encode(this) { char -> a[i++] = char.code.toByte() }
+                a
             }
         }
     }

--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -282,7 +282,7 @@ public abstract class EncoderDecoder<C: EncoderDecoder.Config>(config: C): Encod
          * e.g.
          *
          *     protected override fun toStringAddSettings(): Set<Setting> {
-         *         return buildSet {
+         *         return LinkedHashSet<Setting>(3, 1.0f).apply {
          *             add(Setting(name = "setting1", value = setting1))
          *             add(Setting(name = "setting2", value = setting2))
          *         }
@@ -294,7 +294,8 @@ public abstract class EncoderDecoder<C: EncoderDecoder.Config>(config: C): Encod
         protected abstract fun toStringAddSettings(): Set<Setting>
 
         /**
-         * Additional setting to [Config], unique to the implementing class.
+         * Additional setting to [Config], unique to the implementing class. Used
+         * in the [toString] output
          * */
         protected inner class Setting(name: String, @JvmField public val value: Any?) {
 

--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-EncoderDecoder.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-EncoderDecoder.kt
@@ -95,9 +95,7 @@ internal inline fun <C: Config> Encoder<C>.encode(
     if (data.isEmpty()) return
 
     newEncoderFeed(out).use { feed ->
-        for (byte in data) {
-            feed.consume(byte)
-        }
+        data.forEach { b -> feed.consume(b) }
     }
 }
 

--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderAction.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderAction.kt
@@ -47,7 +47,7 @@ public fun interface DecoderAction {
      *         }
      *     )
      *
-     *     val bits = "48656c6c6f20576f726c6421".map { char ->
+     *     val bits = "48656C6C6F20576F726C6421".map { char ->
      *         parser.parse(char, isConstantTime = true)
      *             ?: error("Invalid Char[$char])
      *     }

--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/FeedBuffer.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/FeedBuffer.kt
@@ -45,9 +45,7 @@ constructor(
 ) {
 
     init {
-        require(blockSize > 0) {
-            "blockSize must be greater than 0"
-        }
+        require(blockSize > 0) { "blockSize must be greater than 0" }
     }
 
     @get:JvmName("count")


### PR DESCRIPTION
Closes #151 