### PR TITLE
Deprecate `DecoderInput` constructor for `ByteArray`

### DIFF
--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -228,6 +228,7 @@ public sealed class Decoder<C: EncoderDecoder.Config>(public val config: C) {
         @Throws(EncodingException::class)
         @Deprecated(message = "Should not utilize. Underlying Byte to Char conversion can produce incorrect results")
         public fun ByteArray.decodeToByteArray(decoder: Decoder<*>): ByteArray {
+            @Suppress("DEPRECATION")
             return decoder.decode(DecoderInput(this)) { feed ->
                 forEach { b -> feed.consume(b.toInt().toChar()) }
             }

--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
@@ -38,6 +38,9 @@ public class DecoderInput {
     private constructor(input: Any, size: Int) { this.input = input; this.size = size }
     public constructor(input: CharSequence): this(input, input.length)
     public constructor(input: CharArray): this(input, input.size)
+
+    /** @suppress */
+    @Deprecated(message = "Should not utilize. Underlying Byte to Char conversion can produce incorrect results")
     public constructor(input: ByteArray): this(input, input.size)
 
     @Throws(EncodingException::class)

--- a/library/core/src/commonTest/kotlin/io/matthewnelson/encoding/core/util/DecoderInputUnitTest.kt
+++ b/library/core/src/commonTest/kotlin/io/matthewnelson/encoding/core/util/DecoderInputUnitTest.kt
@@ -133,6 +133,7 @@ class DecoderInputUnitTest {
             inputSize// pass
         })
 
+        @Suppress("DEPRECATION")
         config.decodeOutMaxSizeOrFail(DecoderInput(validInput))
     }
 


### PR DESCRIPTION
Forgot to do this in #156 when taking care of #152