### PR TITLE
Ensure `LineBreakOutFeed` is reset when `Encoder.Feed.flush` is called

### DIFF
--- a/library/base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -125,6 +125,8 @@ public class Base16: EncoderDecoder<Base16.Config> {
          *     isLenient(enable = false)
          *     lineBreak(interval = 16)
          *     // 48656C6C6F20576F726C6421
+         *
+         * @see [EncoderDecoder.Config.lineBreakInterval]
          * */
         public fun lineBreak(interval: Byte): Builder = apply { _lineBreakInterval = interval }
 
@@ -365,7 +367,7 @@ public class Base16: EncoderDecoder<Base16.Config> {
         }
     }
 
-    private abstract inner class EncoderFeed(private val out: Encoder.OutFeed): Encoder<Config>.Feed() {
+    private abstract inner class EncoderFeed(private val out: Encoder.OutFeed): Encoder<Config>.Feed(out) {
 
         protected abstract fun Encoder.OutFeed.output2(i1: Int, i2: Int)
 

--- a/library/base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -540,6 +540,8 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
              *     isLenient(enable = false)
              *     lineBreak(interval = 16)
              *     // JBSWY3DPEBLW64TMMQQQ====
+             *
+             * @see [EncoderDecoder.Config.lineBreakInterval]
              * */
             public fun lineBreak(interval: Byte): Builder = apply { _lineBreakInterval = interval }
 
@@ -857,6 +859,8 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
              *     isLenient(enable = false)
              *     lineBreak(interval = 16)
              *     // 91IMOR3F41BMUSJCCGGG====
+             *
+             * @see [EncoderDecoder.Config.lineBreakInterval]
              * */
             public fun lineBreak(interval: Byte): Builder = apply { _lineBreakInterval = interval }
 
@@ -1200,7 +1204,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
         }
     }
 
-    private abstract inner class EncoderFeed(private val out: Encoder.OutFeed): Encoder<C>.Feed() {
+    private abstract inner class EncoderFeed(private val out: Encoder.OutFeed): Encoder<C>.Feed(out) {
 
         protected abstract fun Encoder.OutFeed.output1(i: Int)
         protected abstract fun Encoder.OutFeed.outputPadding(n: Int)

--- a/library/base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
+++ b/library/base32/src/commonTest/kotlin/io/matthewnelson/encoding/base32/Base32DefaultUnitTest.kt
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("SpellCheckingInspection")
-
 package io.matthewnelson.encoding.base32
 
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
@@ -214,5 +212,4 @@ class Base32DefaultUnitTest: BaseNEncodingTest() {
         useLowercase = true
         checkRandomData()
     }
-
 }

--- a/library/base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -165,6 +165,8 @@ public class Base64: EncoderDecoder<Base64.Config> {
          *     isLenient(enable = false)
          *     lineBreak(interval = 10)
          *     // SGVsbG8gV29ybGQh
+         *
+         * @see [EncoderDecoder.Config.lineBreakInterval]
          * */
         public fun lineBreak(interval: Byte): Builder = apply { _lineBreakInterval = interval }
 
@@ -491,7 +493,7 @@ public class Base64: EncoderDecoder<Base64.Config> {
         }
     }
 
-    private abstract inner class EncoderFeed(private val out: Encoder.OutFeed): Encoder<Config>.Feed() {
+    private abstract inner class EncoderFeed(private val out: Encoder.OutFeed): Encoder<Config>.Feed(out) {
 
         protected abstract fun Encoder.OutFeed.output1(i: Int)
         protected abstract fun Encoder.OutFeed.output4(i1: Int, i2: Int, i3: Int, i4: Int)

--- a/library/core/api/core.api
+++ b/library/core/api/core.api
@@ -53,6 +53,7 @@ public final class io/matthewnelson/encoding/core/Encoder$Companion {
 
 public abstract class io/matthewnelson/encoding/core/Encoder$Feed : io/matthewnelson/encoding/core/EncoderDecoder$Feed {
 	public fun <init> (Lio/matthewnelson/encoding/core/Encoder;)V
+	public fun <init> (Lio/matthewnelson/encoding/core/Encoder;Lio/matthewnelson/encoding/core/Encoder$OutFeed;)V
 	public final fun close ()V
 	public final fun consume (B)V
 	protected abstract fun consumeProtected (B)V
@@ -63,7 +64,12 @@ public abstract class io/matthewnelson/encoding/core/Encoder$Feed : io/matthewne
 }
 
 public abstract interface class io/matthewnelson/encoding/core/Encoder$OutFeed {
+	public static final field Companion Lio/matthewnelson/encoding/core/Encoder$OutFeed$Companion;
+	public static final field NoOp Lio/matthewnelson/encoding/core/Encoder$OutFeed;
 	public abstract fun output (C)V
+}
+
+public final class io/matthewnelson/encoding/core/Encoder$OutFeed$Companion {
 }
 
 public abstract class io/matthewnelson/encoding/core/EncoderDecoder : io/matthewnelson/encoding/core/Encoder {
@@ -191,6 +197,7 @@ public abstract interface class io/matthewnelson/encoding/core/util/FeedBuffer$F
 public final class io/matthewnelson/encoding/core/util/LineBreakOutFeed : io/matthewnelson/encoding/core/Encoder$OutFeed {
 	public final field interval B
 	public fun <init> (BLio/matthewnelson/encoding/core/Encoder$OutFeed;)V
+	public final fun count ()B
 	public fun output (C)V
 	public final fun reset ()V
 }

--- a/library/core/api/core.klib.api
+++ b/library/core/api/core.klib.api
@@ -141,6 +141,9 @@ final class io.matthewnelson.encoding.core.util/LineBreakOutFeed : io.matthewnel
     final val interval // io.matthewnelson.encoding.core.util/LineBreakOutFeed.interval|{}interval[0]
         final fun <get-interval>(): kotlin/Byte // io.matthewnelson.encoding.core.util/LineBreakOutFeed.interval.<get-interval>|<get-interval>(){}[0]
 
+    final var count // io.matthewnelson.encoding.core.util/LineBreakOutFeed.count|{}count[0]
+        final fun <get-count>(): kotlin/Byte // io.matthewnelson.encoding.core.util/LineBreakOutFeed.count.<get-count>|<get-count>(){}[0]
+
     final fun output(kotlin/Char) // io.matthewnelson.encoding.core.util/LineBreakOutFeed.output|output(kotlin.Char){}[0]
     final fun reset() // io.matthewnelson.encoding.core.util/LineBreakOutFeed.reset|reset(){}[0]
 }
@@ -196,10 +199,16 @@ sealed class <#A: io.matthewnelson.encoding.core/EncoderDecoder.Config> io.matth
 
     abstract fun interface OutFeed { // io.matthewnelson.encoding.core/Encoder.OutFeed|null[0]
         abstract fun output(kotlin/Char) // io.matthewnelson.encoding.core/Encoder.OutFeed.output|output(kotlin.Char){}[0]
+
+        final object Companion { // io.matthewnelson.encoding.core/Encoder.OutFeed.Companion|null[0]
+            final val NoOp // io.matthewnelson.encoding.core/Encoder.OutFeed.Companion.NoOp|{}NoOp[0]
+                final fun <get-NoOp>(): io.matthewnelson.encoding.core/Encoder.OutFeed // io.matthewnelson.encoding.core/Encoder.OutFeed.Companion.NoOp.<get-NoOp>|<get-NoOp>(){}[0]
+        }
     }
 
     abstract inner class Feed : io.matthewnelson.encoding.core/EncoderDecoder.Feed<#A> { // io.matthewnelson.encoding.core/Encoder.Feed|null[0]
         constructor <init>() // io.matthewnelson.encoding.core/Encoder.Feed.<init>|<init>(){}[0]
+        constructor <init>(io.matthewnelson.encoding.core/Encoder.OutFeed) // io.matthewnelson.encoding.core/Encoder.Feed.<init>|<init>(io.matthewnelson.encoding.core.Encoder.OutFeed){}[0]
 
         abstract fun consumeProtected(kotlin/Byte) // io.matthewnelson.encoding.core/Encoder.Feed.consumeProtected|consumeProtected(kotlin.Byte){}[0]
         abstract fun doFinalProtected() // io.matthewnelson.encoding.core/Encoder.Feed.doFinalProtected|doFinalProtected(){}[0]

--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -21,6 +21,7 @@ import io.matthewnelson.encoding.core.internal.calculatedOutputNegativeEncodingS
 import io.matthewnelson.encoding.core.internal.closedException
 import io.matthewnelson.encoding.core.internal.isSpaceOrNewLine
 import io.matthewnelson.encoding.core.util.DecoderInput
+import io.matthewnelson.encoding.core.util.LineBreakOutFeed
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -64,25 +65,26 @@ public abstract class EncoderDecoder<C: EncoderDecoder.Config>(config: C): Encod
         public val paddingChar: Char?,
 
         /**
-         * When the [Encoder.encodeToString], [Encoder.encodeToCharArray], and [Decoder.decodeToByteArray]
-         * functions are utilized, an initial buffer is allocated based on the pre-calculated return values
-         * of [encodeOutSize] or [decodeOutMaxSize] (respectively). After encoding/decoding operations have
-         * completed, the initial buffer may be trimmed down to size in the event of an over-allocation. If
-         * that happens, the initial buffer is then dropped and the correct sized copy is returned. Prior
-         * versions always back-filled the initial buffer when this occurred, but that can be expensive for
-         * large data sets and potentially unnecessary if data is known to not be sensitive in nature.
+         * When the functions [Encoder.encodeToString], [Encoder.encodeToCharArray], and
+         * [Decoder.decodeToByteArray] are utilized, an initial buffer is allocated based on the
+         * pre-calculated return values of [encodeOutSize] or [decodeOutMaxSize] (respectively).
+         * After encoding/decoding operations have completed, the initial buffer may be trimmed
+         * to size in the event of an over-allocation. If that happens, the initial buffer is
+         * then dropped and the correct sized copy is returned. Prior versions always back-filled
+         * the initial buffer when this occurred, but that can be expensive for large data sets
+         * and potentially unnecessary if data is known to not be sensitive in nature.
          *
-         * If `true`, the initial buffer (if it was trimmed to size) is back-filled. If `false`, back-filling
-         * is skipped.
+         * If `true`, the initial buffer (if it was trimmed to size) is back-filled. If `false`,
+         * back-filling is skipped.
          * */
         @JvmField
         public val backFillBuffers: Boolean,
     ) {
 
         /**
-         * If greater than `0`, when [lineBreakInterval] number of encoded characters have been output,
-         * the next encoded character will be preceded with the new line character `\n` when utilizing
-         * the [Encoder.encodeToString] and [Encoder.encodeToCharArray] functions.
+         * If greater than `0`, [Encoder.newEncoderFeed] will use the [LineBreakOutFeed] such that
+         * for every [lineBreakInterval] number of encoded characters output, the next encoded
+         * character will be preceded with the new line character `\n`.
          *
          * **NOTE:** This setting will always be `0` if [isLenient] is `false`.
          * */

--- a/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/LineBreakOutFeed.kt
+++ b/library/core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/LineBreakOutFeed.kt
@@ -17,14 +17,15 @@ package io.matthewnelson.encoding.core.util
 
 import io.matthewnelson.encoding.core.Encoder
 import kotlin.jvm.JvmField
+import kotlin.jvm.JvmName
 
 /**
- * A Wrapper around another [Encoder.OutFeed] to hijack
- * the output and insert new line characters at every
- * expressed [interval].
+ * A Wrapper around another [Encoder.OutFeed] to hijack the output and insert
+ * new line characters at every expressed [interval].
  *
  * @param [interval] The interval at which new lines are inserted
  * @param [out] The other [Encoder.OutFeed]
+ *
  * @throws [IllegalArgumentException] if [interval] is less than 0
  * */
 public class LineBreakOutFeed
@@ -39,7 +40,9 @@ public constructor(
         require(interval > 0) { "interval must be greater than 0" }
     }
 
-    private var count: Byte = 0
+    @get:JvmName("count")
+    public var count: Byte = 0
+        private set
 
     /**
      * Resets the [count] to 0

--- a/library/core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
+++ b/library/core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
@@ -277,7 +277,7 @@ class EncoderDecoderFeedUnitTest {
 
             feed.consume(5)
             assertEquals(12, sb.length)
-            assertTrue(sb.toString().lines().size == 2)
+            assertEquals(2, sb.toString().lines().size)
         }
     }
 
@@ -302,6 +302,18 @@ class EncoderDecoderFeedUnitTest {
         feed.consume(5)
         assertEquals(3, invocations)
         assertEquals(Char.MAX_VALUE, output)
+    }
+
+    @Test
+    fun givenEncoderFeed_whenFlushed_thenLineBreakOutFeedIsReset() {
+        val lbf = LineBreakOutFeed(Byte.MAX_VALUE) {}
+        val feed = TestEncoderDecoder(TestConfig()).newEncoderFeed(lbf)
+        assertEquals(0, lbf.count)
+        feed.consume(2)
+        feed.consume(2)
+        assertEquals(2, lbf.count)
+        feed.flush()
+        assertEquals(0, lbf.count)
     }
 
     @Test

--- a/library/core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestEncoderDecoder.kt
+++ b/library/core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestEncoderDecoder.kt
@@ -25,7 +25,7 @@ class TestEncoderDecoder(
     override fun name(): String = "Test"
 
     override fun newEncoderFeedProtected(out: Encoder.OutFeed): Encoder<TestConfig>.Feed {
-        return object : Encoder<TestConfig>.Feed() {
+        return object : Encoder<TestConfig>.Feed(out) {
             override fun consumeProtected(input: Byte) { out.output(Char.MAX_VALUE) }
             override fun doFinalProtected() {
                 encoderDoFinal?.invoke(this) ?: out.output(Char.MIN_VALUE)

--- a/library/utf8/src/commonMain/kotlin/io/matthewnelson/encoding/utf8/UTF8.kt
+++ b/library/utf8/src/commonMain/kotlin/io/matthewnelson/encoding/utf8/UTF8.kt
@@ -517,7 +517,7 @@ public open class UTF8: EncoderDecoder<UTF8.Config> {
     }
 
     // Bytes -> Chars
-    private open inner class EncoderFeed(private val out: Encoder.OutFeed): Encoder<Config>.Feed() {
+    private open inner class EncoderFeed(private val out: Encoder.OutFeed): Encoder<Config>.Feed(out) {
 
         @Throws(EncodingException::class)
         protected open fun Encoder.OutFeed.outputReplacementChar() {


### PR DESCRIPTION
Closes #191 